### PR TITLE
build script: don't reimplement the python print function

### DIFF
--- a/build
+++ b/build
@@ -94,9 +94,7 @@ def say(what):
     Writes a message to the standard output, and then flushes it, so that
     the output doesn't appear out of order.
     """
-    sys.stdout.write(what)
-    sys.stdout.write("\n")
-    sys.stdout.flush()
+    print(what, flush=True)
 
 
 def cache(function):


### PR DESCRIPTION
@jhernand I think the `say()` function is redundant, Python has this functionality built in. Removing it makes the script slightly more readable :)