### PR TITLE
build script: don't mask exceptions

### DIFF
--- a/build
+++ b/build
@@ -758,18 +758,16 @@ def main():
 
     # Run the selected tool:
     code = 0
-    try:
-        if len(sys.argv) > 0 and sys.argv[1] in DIRECT_TOOLS:
-            go_tool(*sys.argv[1:])
-        else:
-            global argv
-            argv = parser.parse_args()
-            if not hasattr(argv, "func"):
-                parser.print_usage()
-                code = 1
-            argv.func()
-    except Exception as error:
-        say(str(error))
+
+    if len(sys.argv) > 0 and sys.argv[1] in DIRECT_TOOLS:
+        go_tool(*sys.argv[1:])
+    else:
+        global argv
+        argv = parser.parse_args()
+        if not hasattr(argv, "func"):
+            parser.print_usage()
+            code = 1
+        argv.func()
 
     # Bye:
     sys.exit(code)


### PR DESCRIPTION
Catching generic Exception this way causes Python to not print
the backtrace, making errors more difficult to debug.

Since all the exception handler was doing is printing the exception
message, it's much better to just remove it entirely.