### PR TITLE
Customers web server: implement /api/clusters (with mock data)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,6 +16,18 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -36,6 +48,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "945a10c5ee43cd4326902ee13616dd27ae12558feb618800d54dea463a47f2fe"
+  inputs-digest = "4ff444ec0c95de46eb14814a36d18b70681d758b5a6a91e2405647f21d006770"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,3 +22,7 @@
 [[constraint]]
   name = "github.com/go-stomp/stomp"
   version = "2.0.0"
+
+[[constraint]]
+  name = "github.com/gorilla/mux"
+  version = "1.6.2"

--- a/cmd/customers-webserver/cluster.go
+++ b/cmd/customers-webserver/cluster.go
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+)
+
+// Cluster represents a cluster
+type Cluster struct {
+	Name          string `json:"name"`
+	ID            int    `json:"id"`
+	CloudProvider string `json:"cloud_provider"`
+	Region        string `json:"region"`
+	Nodes         int    `json:"nodes"`
+	// TODO - figure out the actual parameters a cluster should have
+}
+
+// MockGetClusters return a list of clusters.
+// TODO write an actual GetClusters function to get them from the database
+func MockGetClusters(page int, size int) []Cluster {
+	clusters := make([]Cluster, size)
+	for i := 0; i < size; i++ {
+		clusterNumber := (page + 1) * i
+		if i == 0 {
+			clusterNumber = page
+		}
+		clusters[i] = Cluster{Name: fmt.Sprintf("test%d", clusterNumber), CloudProvider: "AWS", Region: "us-east-1", Nodes: 5, ID: clusterNumber}
+	}
+	return clusters
+}

--- a/cmd/customers-webserver/cluster_handler.go
+++ b/cmd/customers-webserver/cluster_handler.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// ClusterHandler returns an index of all clusters in the system
+func ClusterHandler(w http.ResponseWriter, r *http.Request) {
+	pageParam, ok := r.URL.Query()["page"]
+
+	if !ok || len(pageParam) < 1 {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Missing query parameter: page\n")
+		return
+	}
+	page, err := strconv.Atoi(pageParam[0])
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Bad query param: page, %v\n", err)
+		return
+	}
+
+	sizeParam, ok := r.URL.Query()["size"]
+
+	if !ok || len(sizeParam) < 1 {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Missing query parameter: size\n")
+		return
+	}
+
+	size, err := strconv.Atoi(sizeParam[0])
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "Bad query param: size, %v\n", err)
+		return
+	}
+
+	ret, err := json.Marshal(MockGetClusters(page, size))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Marshal error: %v\n", err)
+	} else {
+		w.WriteHeader(http.StatusOK)
+		w.Write(ret)
+	}
+}

--- a/cmd/customers-webserver/main.go
+++ b/cmd/customers-webserver/main.go
@@ -17,9 +17,17 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 func main() {
-	http.ListenAndServe(":8000", http.FileServer(http.Dir("/usr/local/share/customers-portal")))
+	r := mux.NewRouter()
+	r.HandleFunc("/api/clusters", ClusterHandler)
+	r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("/usr/local/share/customers-portal"))))
+	http.Handle("/", r)
+	fmt.Println("Listening on http://localhost:8000")
+	http.ListenAndServe(":8000", r)
 }


### PR DESCRIPTION
This is a work in progress PR to add a functional customers web server. It adds an endpoint to get a list of clusters. Right now it only contains hardcoded data

There's still a lot to be done. We need to decide on an API, connect it to the caching SQL server, to the message queues, figure out authentication, etc etc, but this is a good starting point.