### PR TITLE
Fix typo in customers service API specification

### DIFF
--- a/cmd/customers-service/customer-service.yaml
+++ b/cmd/customers-service/customer-service.yaml
@@ -18,7 +18,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/componentes/schemas/CustomersList'
+                  $ref: '#/components/schemas/CustomersList'
         default:
           description: unexpected error
           content:
@@ -33,7 +33,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/componentes/schemas/Customer'
+                $ref: '#/components/schemas/Customer'
         default:
           description: unexpected error
           content:
@@ -49,7 +49,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/componentes/schemas/Customer'
+                $ref: '#/components/schemas/Customer'
         default:
           description: unexpected error
           content:
@@ -91,7 +91,7 @@ components:
           type: array
           items:
             type:
-              $ref: '#/componentes/schemas/Customer'
+              $ref: '#/components/schemas/Customer'
     Error:
       type: object
       required:


### PR DESCRIPTION
This patch fixes a typo in the _OpenAPI_ specification of the customers service, otherwise it can't be loaded by tooks like the _Swagger UI_.