### PR TITLE
Use new-project for dedicated portal

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ Those `.tar` files can then be copied to the OpenShirt cluster, and
 uploaded to the image registry:
 
 ```
-$ scp *.tar myhost:.
+$ scp *.tar template.* myhost:.
 $ ssh root@myhost
 # docker load -i dedicated-portal_clusters-service_0.0.0.tar
 # docker load -i dedicated-portal_customers-service_0.0.0.tar

--- a/template.sh
+++ b/template.sh
@@ -20,7 +20,7 @@
 # the application.
 
 # Create the namespace:
-oc create namespace dedicated-portal
+oc new-project dedicated-portal
 
 # Use the template to create the objects:
 oc process \


### PR DESCRIPTION
Currently all the objects are being created under the current namespace (for me it was default).
`new-project` also sets the current project to it's argument.