### PR TITLE
Add `rsync` to sandbox

### DIFF
--- a/sandbox/prepare_vm.yml
+++ b/sandbox/prepare_vm.yml
@@ -28,6 +28,7 @@
       - NetworkManager
       - docker
       - epel-release
+      - rsync
 
   - name: Add admin to the docker group
     user:


### PR DESCRIPTION
This patch changes the sandbox installation scripts so that the `rsync` package is explicitly installed. It is usually already installed, but as we plan to use it from the `Jenkinsfile` it is better to make sure that
it is installed.
