### PR TITLE
update sandbox readme to include new dependencies

### DIFF
--- a/sandbox/README.adoc
+++ b/sandbox/README.adoc
@@ -22,6 +22,7 @@ ansible \
 genisoimage \
 libvirt \
 python34 \
+python34-jinja2 \
 qemu-kvm \
 virt-install
 ```


### PR DESCRIPTION
A recent change in the sandbox build script required
python jinja2 modules. Adding that to the requirements.