### PR TITLE
Add `python34-jinja2` to the oVirt instructions

### DIFF
--- a/sandbox/README.adoc
+++ b/sandbox/README.adoc
@@ -120,7 +120,8 @@ have all the packages installed:
 ansible \
 genisoimage \
 python-ovirt-engine-sdk4 \
-python34
+python34 \
+python34-jinja2
 ```
 
 To create the virtual machine in an _oVirt_ environment you will first make sure


### PR DESCRIPTION
The package is needed for building the sandbox image in both _libvirt_ and _oVirt_, but it is currently only mentioned in the _libvirt instructions.