### PR TITLE
Download ActiveMQ from container

### DIFF
--- a/images/messaging-service/Dockerfile
+++ b/images/messaging-service/Dockerfile
@@ -16,10 +16,27 @@
 
 FROM centos:7
 
-RUN yum install -y java-1.8.0-openjdk-headless libaio && yum clean all
-COPY artemis.tar.gz setup.sh entrypoint.sh etc /tmp/
-ADD etc /tmp/etc/
-RUN /tmp/setup.sh && rm -rf /tmp/*
+RUN \
+    yum install -y \
+        java-1.8.0-openjdk-headless \
+        libaio \
+        wget \
+        && \
+    yum clean all
+
+COPY \
+    setup.sh \
+    entrypoint.sh \
+    etc \
+    /tmp/
+
+ADD \
+    etc \
+    /tmp/etc/
+
+RUN \
+    /tmp/setup.sh && \
+    rm -rf /tmp/*
 
 EXPOSE 61613 61616
 

--- a/images/messaging-service/Downloads
+++ b/images/messaging-service/Downloads
@@ -1,1 +1,0 @@
-125bdc3516fd051221d06ea2faf26625fb833e15904cccba5e797f2405769ec8 https://www.apache.org/dyn/closer.cgi?filename=activemq/activemq-artemis/2.6.0/apache-artemis-2.6.0-bin.tar.gz&action=download artemis.tar.gz

--- a/images/messaging-service/setup.sh
+++ b/images/messaging-service/setup.sh
@@ -21,6 +21,12 @@
 # Change to the directory where all the files have been copied:
 cd /tmp
 
+# Download the tarball:
+wget \
+  --output-document artemis.tar.gz \
+  "https://www.apache.org/dyn/closer.cgi?filename=activemq/activemq-artemis/2.6.0/apache-artemis-2.6.0-bin.tar.gz&action=download"
+echo "125bdc3516fd051221d06ea2faf26625fb833e15904cccba5e797f2405769ec8 artemis.tar.gz" | sha256sum --check
+
 # Uncompress the tarball:
 tar -xf artemis.tar.gz
 


### PR DESCRIPTION
Currently the _ActiveMQ_ tarball is downloaded by the build script, before building the container. The build script caches it in the `.downloads` directory in order to avoid downloading it repeatedly. But
this directory is not used in the continuous integration environments. For example, when building in Jenkins the tarball is downloaded everytime. To avoid that this patch moves the download to the build of the container. This way it will be cached as part of the container build caching process. The net result is a couple of minutes less in most builds, and a shorter build script.