### PR TITLE
Send slack notification when pipeline fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,10 @@ pipeline {
   }
 
   post {
+    failure {
+      slackSend color: "danger", message: "Deployment pipeline failed, see the details <${env.BUILD_URL}|here>."
+    }
+
     always {
       cleanWs()
     }


### PR DESCRIPTION
This patch changes the _Jenkins_ pipeline of the project so it will send a notification to the _Slack_ channel when it fails.