### PR TITLE
Enable ActiveMQ console

### DIFF
--- a/images/messaging-service/Dockerfile
+++ b/images/messaging-service/Dockerfile
@@ -38,6 +38,8 @@ RUN \
     /tmp/setup.sh && \
     rm -rf /tmp/*
 
-EXPOSE 61613 61616
+# 8161 - Administration console.
+# 61613 - STOMP acceptor.
+EXPOSE 8161 61613
 
 CMD ["/root/entrypoint.sh"]

--- a/images/messaging-service/entrypoint.sh
+++ b/images/messaging-service/entrypoint.sh
@@ -27,10 +27,15 @@ exec java \
   -Dartemis.instance.etc="/etc/artemis" \
   -Dartemis.instance="/var/lib/artemis" \
   -Ddata.dir="/var/lib/artemis/data" \
+  -Dhawtio.offline="true" \
+  -Dhawtio.realm="activemq" \
+  -Dhawtio.role="admins" \
+  -Dhawtio.rolePrincipalClasses="org.apache.activemq.artemis.spi.core.security.jaas.RolePrincipal" \
   -Djava.io.tmpdir="/var/lib/artemis/tmp" \
   -Djava.library.path="/usr/share/artemis/bin/lib/linux-$(uname -m)" \
   -Djava.security.auth.login.config="/etc/artemis/login.config" \
   -Djava.util.logging.manager="org.jboss.logmanager.LogManager" \
+  -Djolokia.policyLocation="file:/etc/artemis/jolokia-access.xml" \
   -Dlogging.configuration="file:/etc/artemis/logging.properties" \
   org.apache.activemq.artemis.boot.Artemis \
   run

--- a/images/messaging-service/etc/bootstrap.xml
+++ b/images/messaging-service/etc/bootstrap.xml
@@ -17,6 +17,24 @@ limitations under the License.
 -->
 
 <broker xmlns="http://activemq.org/schema">
+
+   <!-- Authentication domain: -->
    <jaas-security domain="activemq"/>
+
+   <!-- Broker configuration: -->
    <server configuration="file:/etc/artemis/broker.xml"/>
+
+   <!-- Console configuration: -->
+   <web
+     bind="https://0.0.0.0:8161"
+     path="web"
+     keyStorePath="/etc/artemis/service.p12"
+     keyStorePassword="redhat123">
+
+     <app url="activemq-branding" war="activemq-branding.war"/>
+     <app url="artemis-plugin" war="artemis-plugin.war"/>
+     <app url="console" war="console.war"/>
+
+   </web>
+
 </broker>

--- a/images/messaging-service/etc/broker.xml
+++ b/images/messaging-service/etc/broker.xml
@@ -47,7 +47,7 @@ limitations under the License.
     <critical-analyzer-policy>HALT</critical-analyzer-policy>
 
     <acceptors>
-      <acceptor name="artemis">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE;useEpoll=true;sslEnabled=true;keyStorePath=/etc/artemis/service.p12;keyStorePassword=redhat123</acceptor>
+      <acceptor name="core">tcp://0.0.0.0:61616?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE;useEpoll=true;sslEnabled=true;keyStorePath=/etc/artemis/service.p12;keyStorePassword=redhat123</acceptor>
       <acceptor name="stomp">tcp://0.0.0.0:61613?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=STOMP;useEpoll=true;sslEnabled=true;keyStorePath=/etc/artemis/service.p12;keyStorePassword=redhat123</acceptor>
     </acceptors>
 

--- a/images/messaging-service/etc/jolokia-access.xml
+++ b/images/messaging-service/etc/jolokia-access.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<restrict>
+
+  <!-- TODO: This should contain the URL of the console as seen by the web
+       browser, something like this:
+
+       *://messaging-console.example.com*
+
+       But at the moment it isn't possible, because this file is part of the
+       image, and the image is built before that information is known. For
+       now we are allowing access to all authenticated users.-->
+  <cors>
+    <allow-origin>*</allow-origin>
+    <strict-checking/>
+  </cors>
+
+</restrict>

--- a/images/messaging-service/etc/management.xml
+++ b/images/messaging-service/etc/management.xml
@@ -24,19 +24,19 @@ limitations under the License.
       <entry domain="hawtio"/>
     </whitelist>
     <default-access>
-      <access method="list*" roles="amq"/>
-      <access method="get*" roles="amq"/>
-      <access method="is*" roles="amq"/>
-      <access method="set*" roles="amq"/>
-      <access method="*" roles="amq"/>
+      <access method="list*" roles="admins"/>
+      <access method="get*" roles="admins"/>
+      <access method="is*" roles="admins"/>
+      <access method="set*" roles="admins"/>
+      <access method="*" roles="admins"/>
     </default-access>
     <role-access>
       <match domain="org.apache.activemq.artemis">
-        <access method="list*" roles="amq"/>
-        <access method="get*" roles="amq"/>
-        <access method="is*" roles="amq"/>
-        <access method="set*" roles="amq"/>
-        <access method="*" roles="amq"/>
+        <access method="list*" roles="admins"/>
+        <access method="get*" roles="admins"/>
+        <access method="is*" roles="admins"/>
+        <access method="set*" roles="admins"/>
+        <access method="*" roles="admins"/>
       </match>
     </role-access>
   </authorisation>

--- a/images/messaging-service/setup.sh
+++ b/images/messaging-service/setup.sh
@@ -25,8 +25,8 @@ cd /tmp
 wget \
   --quiet \
   --output-document artemis.tar.gz \
-  "https://www.apache.org/dyn/closer.cgi?filename=activemq/activemq-artemis/2.6.0/apache-artemis-2.6.0-bin.tar.gz&action=download"
-echo "125bdc3516fd051221d06ea2faf26625fb833e15904cccba5e797f2405769ec8 artemis.tar.gz" | sha256sum --check
+  "https://www.apache.org/dyn/closer.cgi?filename=activemq/activemq-artemis/2.6.1/apache-artemis-2.6.1-bin.tar.gz&action=download"
+echo "b56d27107c6b362eb31a85d2a4720134b3142c5f2ed61d44a08eda57fc3764d6 artemis.tar.gz" | sha256sum --check
 
 # Uncompress the tarball:
 tar -xf artemis.tar.gz

--- a/images/messaging-service/setup.sh
+++ b/images/messaging-service/setup.sh
@@ -34,7 +34,6 @@ tar -xf artemis.tar.gz
 # Remove the things that we don't want to install:
 pushd apache-artemis-*
   rm -rf examples
-  rm -rf web
   rm lib/artemis-amqp-protocol-*.jar
   rm lib/artemis-hornetq-protocol-*.jar
   rm lib/artemis-mqtt-protocol-*.jar

--- a/template.yml
+++ b/template.yml
@@ -83,8 +83,26 @@ objects:
     selector:
       app: messaging-service
     ports:
-    - port: 61613
+    - name: console
+      port: 8161
+      targetPort: 8161
+    - name: acceptor
+      port: 61613
       targetPort: 61613
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: messaging-console
+  spec:
+    host: messaging-console.${DOMAIN}
+    to:
+      kind: Service
+      name: messaging-service
+    port:
+      targetPort: console
+    tls:
+      termination: passthrough
 
 - apiVersion: v1
   kind: Route
@@ -95,6 +113,8 @@ objects:
     to:
       kind: Service
       name: messaging-service
+    port:
+      targetPort: acceptor
     tls:
       termination: passthrough
 


### PR DESCRIPTION
Currently the _ActiveMQ_ container has the management console. This patch enables it. The console will be available via the route for host name `messaging-console`. For example, if the domain selected is `example.com` then the console will be available in the following URL:

```
https://messaging-console.example.com/console/
```
    
The default user name and password are `admin` and `redhat123`.
