### PR TITLE
Avoid nested exceptions due to cache in 'build.py'

### DIFF
--- a/build.py
+++ b/build.py
@@ -86,9 +86,9 @@ def cache(function):
     cache = dict()
 
     def helper(*key):
-        try:
+        if key in cache:
             value = cache[key]
-        except KeyError:
+        else:
             value = function(*key)
             cache[key] = value
         return value


### PR DESCRIPTION
Currently when the build fails in a function whose result is cached we generate a nested exception message. For example, if the `docker` command doesn't exist the error message is like this:

```
Running command 'docker build --tag=dedicated-portal/clusters-service:latest .'
Traceback (most recent call last):
  File "./build.py", line 90, in helper
    value = cache[key]
KeyError: ()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./build.py", line 90, in helper
    value = cache[key]
KeyError: ('clusters-service',)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./build.py", line 694, in <module>
    main()
  File "./build.py", line 687, in main
    argv.func()
  File "./build.py", line 619, in build_images
    image_tags = ensure_images()
  File "./build.py", line 92, in helper
    value = function(*key)
  File "./build.py", line 395, in ensure_images
    image_tag = ensure_image(image_name)
  File "./build.py", line 92, in helper
    value = function(*key)
  File "./build.py", line 494, in ensure_image
    process = subprocess.Popen(args=args, cwd=tmp_dir)
  File "/usr/lib64/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib64/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'docker': 'docker'
```

That error message is confusing. To make it less confusing this patch changes the `cache` function so that it will not generate these nested exception messages. The message will be now like this:

```
Running command 'docker build --tag=dedicated-portal/clusters-service:latest .'
Traceback (most recent call last):
  File "./build.py", line 694, in <module>
    main()
  File "./build.py", line 687, in main
    argv.func()
  File "./build.py", line 619, in build_images
    image_tags = ensure_images()
  File "./build.py", line 92, in helper
    value = function(*key)
  File "./build.py", line 395, in ensure_images
    image_tag = ensure_image(image_name)
  File "./build.py", line 92, in helper
    value = function(*key)
  File "./build.py", line 494, in ensure_image
    process = subprocess.Popen(args=args, cwd=tmp_dir)
  File "/usr/lib64/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib64/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'docker': 'docker'
```