### PR TITLE
Add a serve command to the customer service

### DIFF
--- a/images/customers-service/Dockerfile
+++ b/images/customers-service/Dockerfile
@@ -20,4 +20,10 @@ COPY customers-service /usr/local/bin/
 
 EXPOSE 8000
 
-CMD /usr/local/bin/customers-service
+CMD [ \
+    "serve" \
+]
+
+ENTRYPOINT [ \
+    "/usr/local/bin/customers-service" \
+]

--- a/template.yml
+++ b/template.yml
@@ -249,8 +249,6 @@ objects:
         - name: service
           image: dedicated-portal/customers-service:${VERSION}
           imagePullPolicy: IfNotPresent
-          command:
-          - /usr/local/bin/customers-service
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
**Description**

Add a serve command to the customer service.

**Terminal dump**

Running server:
```
$GOBIN/customers-service serve
I0626 16:43:40.592917     756 server.go:91] Starting customers-service server at 0.0.0.0:8080.

```

Gloabl options:
```
$ $GOBIN/customers-service 
A tool that can service customers.

Usage:
  customers-service [command]

Available Commands:
  help        Help about any command
  serve       Serve a customers service serrvice

Flags:
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for customers-service
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "customers-service [command] --help" for more information about a command.
```

Serve options:
```
$ $GOBIN/customers-service help serve
Serve a customers service serrvice.

Usage:
  customers-service serve [flags]

Flags:
  -h, --help          help for serve
      --host string   The IP address or port number of the serveer. (default "0.0.0.0")
      --port int      The port number of the server. (default 8080)

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

```