### PR TITLE
Add check fmt to the travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ install:
 - go get github.com/client9/misspell/cmd/misspell
 
 script:
-- make images
+# Check for `go fmt` errors
+- if [ $(gofmt -s -l ./pkg/ ./cmd/ | wc -l) -eq 0 ]; then true; else false; fi;
+# Check for `golint` errors
 - make lint
+# Check for common misspell errors (this is not a speller)
 - misspell -error cmd/** pkg/** README.adoc
+# Check that everything compiles
+- make images

--- a/build.py
+++ b/build.py
@@ -216,7 +216,6 @@ def ensure_src_link(import_path, src_path):
     given import path appear in the 'GOPATH' expected by go tools. Returns
     the full path of the link.
     """
-    project_dir = ensure_project_dir()
     go_src = ensure_go_src()
     src_link = os.path.join(go_src, import_path)
     link_dir = os.path.dirname(src_link)
@@ -615,13 +614,8 @@ def lint():
     """
     Runs the 'golint' tool on all the source files.
     """
-    go_tool(
-        "golint",
-        "-min_confidence", "0.9",
-        "-set_exit_status",
-        "./pkg/...",
-        "./cmd/...",
-    )
+    go_tool("golint", "-set_exit_status", "./pkg/...")
+    go_tool("golint", "-set_exit_status", "./cmd/...")
 
 
 def fmt():


### PR DESCRIPTION
**Description**

a. Add check fmt to the travis file. Makes commit that has a fmt error fail.
b. Fix the golint travis check, currently it does not work because it can't handle two dirs.

**Travis dump**

```
$ if [ $(gofmt -s -l ./pkg/ ./cmd/ | wc -l) -eq 0 ]; then true; else false; fi;
The command "if [ $(gofmt -s -l ./pkg/ ./cmd/ | wc -l) -eq 0 ]; then true; else false; fi;" exited with 0.
```