### PR TITLE
Add schema migrations & postgres implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -43,6 +43,18 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/golang-migrate/migrate"
+  packages = [
+    ".",
+    "database",
+    "database/postgres",
+    "source",
+    "source/file"
+  ]
+  revision = "bcd996f3df28363f43e2d0935484c4559537a3eb"
+  version = "v3.3.0"
+
+[[projects]]
   name = "github.com/golang/glog"
   packages = ["."]
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
@@ -116,7 +128,7 @@
     "internal/timeseries",
     "trace"
   ]
-  revision = "afe8f62b1d6bbd81f31868121a50b06d8188e1f9"
+  revision = "ed29d75add3d7c4bf7ca65aac0c6df3d1420216f"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -143,7 +155,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "80063a038e333bbe006c878e4c5ce4c74d055498"
+  revision = "ff3583edef7de132f219f0efc00e097cabcc0ec0"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -181,6 +193,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "284d2cd836a2b4211ef767a282244de1d50400a14d2d985ada2f9c81c2ff2c00"
+  inputs-digest = "d36c34d7bb0191167a457d59518beef12d6251fd0903db4625fd9eb1f65b384e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,3 +30,7 @@
 [[constraint]]
   name = "github.com/container-mgmt/messaging-library"
   version = "0.1.0"
+
+[[constraint]]
+  name = "github.com/golang-migrate/migrate"
+  version = "3.3.0"

--- a/cmd/clusters-service/clusters_service.go
+++ b/cmd/clusters-service/clusters_service.go
@@ -1,19 +1,29 @@
 package main
 
-import "time"
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq"
+	"github.com/segmentio/ksuid"
+)
 
 // ClustersService performs operations on clusters.
 type ClustersService interface {
 	List(args ListArguments) (clusters ClustersResult, err error)
+	Create(name string) (result Cluster, err error)
+	Get(uuid string) (result Cluster, err error)
 }
 
 // GenericClustersService is a ClusterService placeholder implementation.
-type GenericClustersService struct{}
+type GenericClustersService struct {
+	connectionUrl string
+}
 
 // ListArguments are arguments relevant for listing objects.
 type ListArguments struct {
-	Skip  int
-	Limit int
+	Page int
+	Size int
 }
 
 // ClustersResult is a result for a List request of Clusters.
@@ -26,27 +36,106 @@ type ClustersResult struct {
 
 // Cluster represents an OpenShift cluster.
 type Cluster struct {
-	Name              string
-	UUID              string
-	CreationTimestamp time.Time
+	Name string
+	UUID string
 }
 
 // NewClustersService Creates a new ClustersService.
-func NewClustersService() ClustersService {
-	return new(GenericClustersService)
+func NewClustersService(connectionUrl string) ClustersService {
+	service := new(GenericClustersService)
+	service.connectionUrl = connectionUrl
+	return service
 }
 
 // List returns lists of clusters.
 func (cs GenericClustersService) List(args ListArguments) (result ClustersResult, err error) {
-	result.Page = 0
-	result.Size = 1
-	result.Total = 1
-	result.Items = []Cluster{
-		{
-			Name:              "Static Cluster",
-			UUID:              "8a83de13-7a3e-4928-828b-74ffede43964",
-			CreationTimestamp: time.Now(),
-		},
+	result.Items = make([]Cluster, 0)
+	db, err := sql.Open("postgres", cs.connectionUrl)
+	if err != nil {
+		return ClustersResult{}, fmt.Errorf("Error openning connection: %v", err)
 	}
-	return
+	defer db.Close()
+	fmt.Printf("LIMIT: [%d] OFFESET: [%d]\n", args.Size, args.Page*args.Size)
+	rows, err := db.Query(`SELECT uuid, name
+		FROM clusters
+		ORDER BY uuid
+		LIMIT $1
+		OFFSET $2`,
+		args.Size,
+		args.Page*args.Size,
+	)
+	if err != nil {
+		return ClustersResult{}, fmt.Errorf("Error executing query: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var uuid, name string
+		err = rows.Scan(&uuid, &name)
+		if err != nil {
+			return ClustersResult{}, err
+		}
+		result.Items = append(result.Items, Cluster{
+			Name: name,
+			UUID: uuid,
+		})
+	}
+	err = rows.Err() // get any error encountered during iteration
+	if err != nil {
+		return ClustersResult{}, err
+	}
+	result.Page = args.Page
+	result.Size = len(result.Items)
+	return result, nil
+}
+
+// Create saves a new cluster definition in the Database
+func (cs GenericClustersService) Create(name string) (result Cluster, err error) {
+	uuid, err := ksuid.NewRandom()
+	fmt.Printf("Generated id: %s\n", uuid)
+	if err != nil {
+		return Cluster{}, err
+	}
+	db, err := sql.Open("postgres", cs.connectionUrl)
+	if err != nil {
+		return Cluster{}, err
+	}
+	defer db.Close()
+	stmt, err := db.Prepare(`INSERT INTO clusters (uuid, name)
+		VALUES ($1, $2)`)
+	if err != nil {
+		return Cluster{}, err
+	}
+	defer stmt.Close()
+	queryResult, err := stmt.Exec(uuid, name)
+	if err != nil {
+		return Cluster{}, err
+	}
+	inserted, err := queryResult.RowsAffected()
+	if err != nil {
+		return Cluster{}, err
+	}
+	if inserted != 1 {
+		return Cluster{}, fmt.Errorf("Error: [%d] rows inserted. 1 expected",
+			inserted,
+		)
+	}
+	return Cluster{
+		Name: name,
+		UUID: fmt.Sprintf("%s", uuid),
+	}, nil
+}
+
+// Get returns a single cluster by id
+func (cs GenericClustersService) Get(uuid string) (result Cluster, err error) {
+	db, err := sql.Open("postgres", cs.connectionUrl)
+	if err != nil {
+		return Cluster{}, err
+	}
+	defer db.Close()
+	var name string
+	err = db.QueryRow("SELECT uuid, name FROM clusters	WHERE uuid = $1", uuid).Scan(&uuid, &name)
+	if err != nil {
+		return Cluster{}, err
+	}
+	return Cluster{uuid, name}, nil
 }

--- a/cmd/clusters-service/clusters_service_test.go
+++ b/cmd/clusters-service/clusters_service_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func TestList(t *testing.T) {
+	t.Fatal("This test fails")
+}

--- a/cmd/clusters-service/main.go
+++ b/cmd/clusters-service/main.go
@@ -27,14 +27,15 @@ import (
 func main() {
 	// Set up signals so we handle the first shutdown signal gracefully:
 	stopCh := signals.SetupHandler()
-
+	url := ConnectionURL()
 	err := sql.EnsureSchema(
-		"/usr/local/share/clusters-service/migrations", ConnectionURL(),
+		"/usr/local/share/clusters-service/migrations",
+		url,
 	)
 	if err != nil {
 		panic(err)
 	}
-	service := NewClustersService(ConnectionURL())
+	service := NewClustersService(url)
 	fmt.Println("Created cluster service.")
 
 	// This is temporary and should be replaced with reading from the queue

--- a/cmd/clusters-service/openapi.yaml
+++ b/cmd/clusters-service/openapi.yaml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 info:
-  version: "0.1"
+  version: '0.1'
   title: Clusters Service Application.
   description: Clusters Service Application for the Openshift dedicated portal.
   license:
     name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0'
   contact:
     name: API Support
     email: TBD@redhat.com
@@ -14,7 +14,7 @@ paths:
     get:
       description: Returns lists of clusters
       responses:
-        "200":
+        '200':
           description: A list of clusters
           content:
             application/json:
@@ -25,7 +25,65 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: '#/components/schemas/Error'
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+          description: |-
+            The first page to return results from
+            see size
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1000
+          description: |-
+            How many results to place in a page of results
+            see page
+      summary: ''
+    post:
+      description: Create a Cluster
+      responses:
+        '200':
+          description: The newly created Clustrer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cluster'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/clusters/{id}':
+    get:
+      description: Retrieves cluster by id
+      parameters:
+        - name: id
+          in: path
+          description: ID of cluster to show
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: information on a specific cluster
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cluster'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     Cluster:
@@ -44,10 +102,15 @@ components:
     Error:
       type: object
       required:
-      - message
-      - code
+        - message
+        - code
       properties:
         message:
           type: string
         code:
           type: integer
+  links: {}
+  callbacks: {}
+  securitySchemes: {}
+security: []
+servers: []

--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -54,7 +54,7 @@ func (s Server) listClusters(w http.ResponseWriter, r *http.Request) {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
 	}
-	b, err := json.Marshal(results)
+	b, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
@@ -83,7 +83,7 @@ func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	b, err := json.Marshal(result)
+	b, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -102,7 +102,7 @@ func (s Server) getCluster(w http.ResponseWriter, r *http.Request) {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
 	}
-	b, err := json.Marshal(cluster)
+	b, err := json.MarshalIndent(cluster, "", "  ")
 	if err != nil {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
@@ -123,7 +123,7 @@ func getQueryParamInt(param string, defaultValue int, r *http.Request) (value in
 }
 
 func writeJSONResponse(w http.ResponseWriter, code int, payload interface{}) {
-	response, _ := json.Marshal(payload)
+	response, _ := json.MarshalIndent(payload, "", "  ")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	w.Write(response)

--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strconv"
 
 	"github.com/gorilla/mux"
 )
@@ -27,21 +29,101 @@ func NewServer(stopCh <-chan struct{}, clusterService ClustersService) *Server {
 func (s Server) start() error {
 	r := mux.NewRouter()
 	r.HandleFunc("/clusters", func(w http.ResponseWriter, r *http.Request) {
-		results, err := s.clusterService.List(ListArguments{})
+		logRequest(r)
+		page, err := getQueryParamInt("page", 0, r)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		size, err := getQueryParamInt("size", 100, r)
+		if err != nil {
+			writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		results, err := s.clusterService.List(ListArguments{Page: page, Size: size})
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 			return
 		}
 		b, err := json.Marshal(results)
 		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		fmt.Fprintf(w, "%s\n", b)
+	}).Methods("GET")
+	r.HandleFunc("/clusters", func(w http.ResponseWriter, r *http.Request) {
+		bytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		var spec Cluster
+		err = json.Unmarshal(bytes, &spec)
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		if spec.UUID != "" {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "uuid must be empty"})
+			return
+		}
+		result, err := s.clusterService.Create(spec.Name)
+		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintf(w, "%s", b)
+		b, err := json.Marshal(result)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintf(w, "%s\n", b)
+	}).Methods("POST")
 
+	r.HandleFunc("/clusters/{uuid}", func(w http.ResponseWriter, r *http.Request) {
+		uuid := mux.Vars(r)["uuid"]
+		if uuid == "" {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "no uuid provided"})
+			return
+		}
+		cluster, err := s.clusterService.Get(uuid)
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		b, err := json.Marshal(cluster)
+		if err != nil {
+			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+			return
+		}
+		fmt.Fprintf(w, "%s\n", b)
 	}).Methods("GET")
+
 	fmt.Println("Listening.")
 	go http.ListenAndServe(":8000", r)
-	fmt.Println("Listened.")
 	return nil
+}
+
+func getQueryParamInt(param string, defaultValue int, r *http.Request) (value int, err error) {
+	valueString, ok := r.URL.Query()[param]
+
+	if !ok || len(valueString) < 1 {
+		return defaultValue, nil
+	}
+	var result int64
+	// This needs to be ParseInt and not Atoi because the interface asks for int64
+	result, err = strconv.ParseInt(valueString[0], 10, 32)
+	return int(result), err
+}
+
+func writeJSONResponse(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(response)
+}
+
+func logRequest(r *http.Request) {
+	fmt.Printf("[%s] [%s]\n", r.Method, r.URL)
 }

--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -28,81 +28,86 @@ func NewServer(stopCh <-chan struct{}, clusterService ClustersService) *Server {
 
 func (s Server) start() error {
 	r := mux.NewRouter()
-	r.HandleFunc("/clusters", func(w http.ResponseWriter, r *http.Request) {
-		logRequest(r)
-		page, err := getQueryParamInt("page", 0, r)
-		if err != nil {
-			writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		size, err := getQueryParamInt("size", 100, r)
-		if err != nil {
-			writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		results, err := s.clusterService.List(ListArguments{Page: page, Size: size})
-		if err != nil {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		b, err := json.Marshal(results)
-		if err != nil {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		fmt.Fprintf(w, "%s\n", b)
-	}).Methods("GET")
-	r.HandleFunc("/clusters", func(w http.ResponseWriter, r *http.Request) {
-		bytes, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		var spec Cluster
-		err = json.Unmarshal(bytes, &spec)
-		if err != nil {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		if spec.UUID != "" {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "uuid must be empty"})
-			return
-		}
-		result, err := s.clusterService.Create(spec.Name)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		b, err := json.Marshal(result)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		fmt.Fprintf(w, "%s\n", b)
-	}).Methods("POST")
-
-	r.HandleFunc("/clusters/{uuid}", func(w http.ResponseWriter, r *http.Request) {
-		uuid := mux.Vars(r)["uuid"]
-		if uuid == "" {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "no uuid provided"})
-			return
-		}
-		cluster, err := s.clusterService.Get(uuid)
-		if err != nil {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		b, err := json.Marshal(cluster)
-		if err != nil {
-			writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
-			return
-		}
-		fmt.Fprintf(w, "%s\n", b)
-	}).Methods("GET")
+	r.HandleFunc("/clusters", s.listClusters).Methods("GET")
+	r.HandleFunc("/clusters", s.createCluster).Methods("POST")
+	r.HandleFunc("/clusters/{uuid}", s.getCluster).Methods("GET")
 
 	fmt.Println("Listening.")
 	go http.ListenAndServe(":8000", r)
 	return nil
+}
+
+func (s Server) listClusters(w http.ResponseWriter, r *http.Request) {
+	logRequest(r)
+	page, err := getQueryParamInt("page", 0, r)
+	if err != nil {
+		writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	size, err := getQueryParamInt("size", 100, r)
+	if err != nil {
+		writeJSONResponse(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	results, err := s.clusterService.List(ListArguments{Page: page, Size: size})
+	if err != nil {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	b, err := json.Marshal(results)
+	if err != nil {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	fmt.Fprintf(w, "%s\n", b)
+}
+
+func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
+	bytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	var spec Cluster
+	err = json.Unmarshal(bytes, &spec)
+	if err != nil {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	if spec.UUID != "" {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "uuid must be empty"})
+		return
+	}
+	result, err := s.clusterService.Create(spec.Name)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	b, err := json.Marshal(result)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprintf(w, "%s\n", b)
+}
+
+func (s Server) getCluster(w http.ResponseWriter, r *http.Request) {
+	uuid := mux.Vars(r)["uuid"]
+	if uuid == "" {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "no uuid provided"})
+		return
+	}
+	cluster, err := s.clusterService.Get(uuid)
+	if err != nil {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	b, err := json.Marshal(cluster)
+	if err != nil {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
+		return
+	}
+	fmt.Fprintf(w, "%s\n", b)
 }
 
 func getQueryParamInt(param string, defaultValue int, r *http.Request) (value int, err error) {

--- a/images/clusters-service/Dockerfile
+++ b/images/clusters-service/Dockerfile
@@ -17,6 +17,7 @@
 FROM centos:7
 
 COPY clusters-service /usr/local/bin/
+COPY migrations /usr/local/share/clusters-service/migrations
 
 EXPOSE 8000
 

--- a/images/clusters-service/migrations/1530102671_create_schema.down.sql
+++ b/images/clusters-service/migrations/1530102671_create_schema.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE clusters;

--- a/images/clusters-service/migrations/1530102671_create_schema.up.sql
+++ b/images/clusters-service/migrations/1530102671_create_schema.up.sql
@@ -1,0 +1,3 @@
+CREATE TABLE clusters (
+  uuid varchar(37) NOT NULL UNIQUE
+);

--- a/images/clusters-service/migrations/1530102892_add_cluster_name.down.sql
+++ b/images/clusters-service/migrations/1530102892_add_cluster_name.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE clusters
+DROP COLUMN name;

--- a/images/clusters-service/migrations/1530102892_add_cluster_name.up.sql
+++ b/images/clusters-service/migrations/1530102892_add_cluster_name.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE clusters
+ADD COLUMN name text NOT NULL;

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -1,0 +1,90 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/golang-migrate/migrate"
+	// Register the migrate postgresl driver
+	_ "github.com/golang-migrate/migrate/database/postgres"
+	_ "github.com/golang-migrate/migrate/source/file"
+	_ "github.com/lib/pq"
+)
+
+// EnsureSchema makes sure our DB's schema matches that defined by schemaPath.
+// It migrates it if needed and returns error if it can't do so.
+func EnsureSchema(schemaPath, connectionUrl string) error {
+	waitForDatabase(connectionUrl)
+	m, err := migrate.New(
+		fmt.Sprintf("file:///%s", schemaPath),
+		connectionUrl,
+	)
+	if err != nil {
+		return fmt.Errorf("migrate.New: %v", err)
+	}
+	defer m.Close()
+
+	err = outputVersion(m)
+	if err != nil {
+		return fmt.Errorf("outputVersion: %v", err)
+	}
+	runMigration(m)
+	if err != nil {
+		return fmt.Errorf("migrate: %v", err)
+	}
+	outputVersion(m)
+	if err != nil {
+		return fmt.Errorf("outputVersion: %v", err)
+	}
+	return nil
+}
+
+func waitForDatabase(connectionUrl string) {
+	for {
+		err := tryConnect(connectionUrl)
+		if err != nil {
+			fmt.Println("Could not connect: ", err)
+			time.Sleep(500 * time.Millisecond)
+		} else {
+			return
+		}
+	}
+}
+
+func tryConnect(connectionURL string) error {
+	db, err := sql.Open("postgres", connectionURL)
+	defer db.Close()
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("sql.Open: %v...", err))
+	}
+	err = db.Ping()
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("db.Ping: %v...", err))
+	}
+	return nil
+}
+
+func outputVersion(m *migrate.Migrate) error {
+	ver, dirty, err := m.Version()
+	if err == migrate.ErrNilVersion {
+		fmt.Print("Current version [0], dirty [false]\n")
+	} else if err != nil {
+		return fmt.Errorf("m.Version: %v", err)
+	} else {
+		fmt.Printf("Current version [%v], dirty [%v]\n", ver, dirty)
+	}
+	return nil
+}
+
+func runMigration(m *migrate.Migrate) error {
+	err := m.Up()
+	if err == migrate.ErrNoChange {
+		fmt.Printf("Already fully migrated!\n")
+	} else if err != nil {
+		return fmt.Errorf("m.Up: %v", err)
+	} else {
+		fmt.Print("Migrated Successfully!\n")
+	}
+	return nil
+}

--- a/pkg/sql/schema_test.go
+++ b/pkg/sql/schema_test.go
@@ -1,0 +1,12 @@
+package sql
+
+import (
+	"testing"
+)
+
+func TestConnectionString(t *testing.T) {
+	str := ConnectionURL()
+	if str != "postgres://:@localhost:5432/?sslmode=disable" {
+		t.Fatal("Unexpected connection string", str)
+	}
+}

--- a/template.yml
+++ b/template.yml
@@ -417,6 +417,13 @@ objects:
         - name: service
           image: dedicated-portal/clusters-service:${VERSION}
           imagePullPolicy: IfNotPresent
+          env:
+          - name: POSTGRESQL_DATABASE
+            value: clusters
+          - name: POSTGRESQL_USER
+            value: service
+          - name: POSTGRESQL_PASSWORD
+            value: ${PASSWORD}
           command:
           - /usr/local/bin/clusters-service
           ports:


### PR DESCRIPTION
```
$ ./hack/cluster-restart.sh

# Get clusters
$ curl  http://clusters-service.127.0.0.1.nip.io/clusters
{
  "Page": 0,
  "Size": 0,
  "Total": 0,
  "Items": []
}

# Create 5 clusters
$ $ for i in $( seq 1 5 ); do
>   curl -X POST -H "Content-Type: application/json" \
>     --data "{\"name\":\"mycluster${i}\"}" \
>     http://clusters-service.127.0.0.1.nip.io/clusters
> done
{
  "Name": "mycluster1",
  "UUID": "16vCmn3jcYxY4vywN0igFcOwoh6"
}
{
  "Name": "mycluster2",
  "UUID": "16vCmp6xOHimgYFeLEmdh8l2e85"
}
{
  "Name": "mycluster3",
  "UUID": "16vCmjzNIGq6fZKLdMU3rN6OSrR"
}
{
  "Name": "mycluster4",
  "UUID": "16vCmoOgUiWDskaNzrjLRGtw2dR"
}
{
  "Name": "mycluster5",
  "UUID": "16vCmoyyQnKiC7jgCwxJ4Gl5RTT"
}

# View logs
$ oc  logs -c service  clusters-service-fc9b8db87-jcgvz 
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Could not connect:  db.Ping: dial tcp [::1]:5432: connect: connection refused...
Current version [0], dirty [false]
Migrated Successfully!
Current version [1530102892], dirty [false]
Created cluster service.
Listening.
Created server.
2018/07/04 13:42:22 received ERROR; Closing underlying connection
Created notifier
Waiting for stop signal
[GET] [/clusters]
LIMIT: [100] OFFESET: [0]
Generated id: 16vCmn3jcYxY4vywN0igFcOwoh6
Generated id: 16vCmp6xOHimgYFeLEmdh8l2e85
Generated id: 16vCmjzNIGq6fZKLdMU3rN6OSrR
Generated id: 16vCmoOgUiWDskaNzrjLRGtw2dR
Generated id: 16vCmoyyQnKiC7jgCwxJ4Gl5RTT

# Get clusters (Note the list is ordered by creation since we are using creation time sortable uuids)
$ curl  http://clusters-service.127.0.0.1.nip.io/clusters
{
  "Page": 0,
  "Size": 5,
  "Total": 0,
  "Items": [
    {
      "Name": "mycluster3",
      "UUID": "16vCmjzNIGq6fZKLdMU3rN6OSrR"
    },
    {
      "Name": "mycluster1",
      "UUID": "16vCmn3jcYxY4vywN0igFcOwoh6"
    },
    {
      "Name": "mycluster4",
      "UUID": "16vCmoOgUiWDskaNzrjLRGtw2dR"
    },
    {
      "Name": "mycluster5",
      "UUID": "16vCmoyyQnKiC7jgCwxJ4Gl5RTT"
    },
    {
      "Name": "mycluster2",
      "UUID": "16vCmp6xOHimgYFeLEmdh8l2e85"
    }
  ]
}

# Get 1 cluster
$ curl  http://clusters-service.127.0.0.1.nip.io/clusters/16vCmp6xOHimgYFeLEmdh8l2e85
{
  "Name": "16vCmp6xOHimgYFeLEmdh8l2e85",
  "UUID": "mycluster2"
}
```

SQL shell:
```
$ oc rsh -c postgresql clusters-service-fc9b8db87-rwrqg 
sh-4.2$ PGPASSWORD=redhat123 psql -h localhost clusters
psql (9.4.14)
Type "help" for help.

clusters=# SELECT * FROM clusters;
            uuid             |    name    
-----------------------------+------------
 16vCmn3jcYxY4vywN0igFcOwoh6 | mycluster1
 16vCmp6xOHimgYFeLEmdh8l2e85 | mycluster2
 16vCmjzNIGq6fZKLdMU3rN6OSrR | mycluster3
 16vCmoOgUiWDskaNzrjLRGtw2dR | mycluster4
 16vCmoyyQnKiC7jgCwxJ4Gl5RTT | mycluster5
(5 rows)
```
