### PR TITLE
Fix typo that led to missing --etcd-entpoint flag

### DIFF
--- a/cmd/customers-service/server.go
+++ b/cmd/customers-service/server.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -60,7 +59,7 @@ func init() {
 		8000,
 		"The port number of the server.",
 	)
-	flag.StringVar(
+	flags.StringVar(
 		&serveArgs.etcdEndpoint,
 		"etcd-endpoint",
 		"localhost:2379",


### PR DESCRIPTION
```diff
 $ .gopath/bin/customers-service serve --help

 Usage:
   customers-service serve [flags]

 Flags:
+      --etcdendpoint string   The endpoint running the etcd data store. (default "localhost:2379")
   -h, --help                  help for serve
       --host string           The IP address or host name of the server. (default "0.0.0.0")
       --port int              The port number of the server. (default 8000)
```