### PR TITLE
customers-service: Switching from etcd to psql

### DIFF
--- a/cmd/customers-service/README.adoc
+++ b/cmd/customers-service/README.adoc
@@ -5,9 +5,15 @@ all the customers of Openshift Dedicated.
 
 == Before you start
 
-Currently the customers-service uses etcd as a main data store - meaning,
-you should have a running etcd cluster one your machine or on a remote host.
-To get started with etcd please refer to: http://github.com/coreos/etcd.
+Currently the customers-service uses postgreSQL as a main data store - meaning,
+you should have a running postgress database one your machine or on a remote host.
+
+To set up the database and appropriate tables run:
+
+[source]
+----
+psql -U postgres -a -f customers.sql
+----
 
 In addition, the customers-service utilizes a messaging-library to publish
 events (e.g. adding / deleting customers). To get started with messaging-library

--- a/cmd/customers-service/server.go
+++ b/cmd/customers-service/server.go
@@ -39,7 +39,7 @@ type Server struct {
 var serveArgs struct {
 	host              string
 	port              int
-	etcdEndpoint      string
+	sqlConnStr        string
 	notificationTopic string
 }
 
@@ -65,10 +65,10 @@ func init() {
 		"The port number of the server.",
 	)
 	flags.StringVar(
-		&serveArgs.etcdEndpoint,
-		"etcd-endpoint",
-		"localhost:2379",
-		"The endpoint running the etcd data store.",
+		&serveArgs.sqlConnStr,
+		"sql-connection-string",
+		"host=localhost port=5432 user=postgres password=1234 dbname=customers sslmode=disable",
+		"The connection string for connection to sql datastore.",
 	)
 	flags.StringVar(
 		&serveArgs.notificationTopic,
@@ -87,7 +87,7 @@ func initServer(service CustomersService) (server *Server) {
 }
 
 func runServe(cmd *cobra.Command, args []string) {
-	service, err := NewEtcdCustomersService(serveArgs.etcdEndpoint)
+	service, err := NewSQLCustomersService(serveArgs.sqlConnStr)
 	if err != nil {
 		panic(fmt.Sprintf("Can't connect to etcd: %v", err))
 	}


### PR DESCRIPTION
## What this does?

This PR is the final step of the move from etcd to sql as a datastore for the customers service.

~~Depends on #61 , once README is merged I would like to update it with this change.~~

cc: @oourfali @jhernand @cben 