### PR TITLE
Add access log handler

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -60,6 +60,12 @@
   version = "v1.1.1"
 
 [[projects]]
+  name = "github.com/gorilla/handlers"
+  packages = ["."]
+  revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
+  version = "v1.3.0"
+
+[[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
@@ -175,6 +181,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9c377d6e8095b844a69362fc9a73cc2d2e5c962a11d10fc3be4fe4d7c34c0e81"
+  inputs-digest = "14b42a41db70d17f067d73a32955748bb7dccc7d9caaf16f2c6ad58714663c1b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,5 +24,9 @@
   version = "1.6.2"
 
 [[constraint]]
+  name = "github.com/gorilla/handlers"
+  version = "1.3.0"
+
+[[constraint]]
   name = "github.com/golang-migrate/migrate"
   version = "3.3.0"

--- a/cmd/clusters-service/clusters_service.go
+++ b/cmd/clusters-service/clusters_service.go
@@ -55,7 +55,6 @@ func (cs GenericClustersService) List(args ListArguments) (result ClustersResult
 		return ClustersResult{}, fmt.Errorf("Error openning connection: %v", err)
 	}
 	defer db.Close()
-	fmt.Printf("LIMIT: [%d] OFFESET: [%d]\n", args.Size, args.Page*args.Size)
 	rows, err := db.Query(`SELECT uuid, name
 		FROM clusters
 		ORDER BY uuid
@@ -91,7 +90,6 @@ func (cs GenericClustersService) List(args ListArguments) (result ClustersResult
 // Create saves a new cluster definition in the Database
 func (cs GenericClustersService) Create(name string) (result Cluster, err error) {
 	uuid, err := ksuid.NewRandom()
-	fmt.Printf("Generated id: %s\n", uuid)
 	if err != nil {
 		return Cluster{}, err
 	}

--- a/cmd/customers-service/handlers.go
+++ b/cmd/customers-service/handlers.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 
@@ -36,8 +35,6 @@ func getQueryParamInt(key string, defaultValue int64, r *http.Request) (value in
 }
 
 func (server *Server) getCustomersList(w http.ResponseWriter, r *http.Request) {
-	log.Println("GET /customers request")
-
 	var ret *CustomersList
 	var err error
 	var page int64
@@ -71,7 +68,6 @@ func (server *Server) getCustomersList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (server *Server) addCustomer(w http.ResponseWriter, r *http.Request) {
-	log.Println("POST /customers request")
 	decoder := json.NewDecoder(r.Body)
 	var customer Customer
 	err := decoder.Decode(&customer)
@@ -88,7 +84,6 @@ func (server *Server) addCustomer(w http.ResponseWriter, r *http.Request) {
 }
 
 func (server *Server) getCustomerByID(w http.ResponseWriter, r *http.Request) {
-	log.Println("GET /customers/{id} request")
 	id := mux.Vars(r)["id"]
 	ret, err := server.service.Get(id)
 	if err != nil {

--- a/cmd/customers-service/server.go
+++ b/cmd/customers-service/server.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/golang/glog"
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 )
@@ -110,7 +112,10 @@ func runServe(cmd *cobra.Command, args []string) {
 		Methods("GET").
 		HandlerFunc(server.getCustomersList)
 
-	log.Fatal(http.ListenAndServe(serverAddress, mainRouter))
+	// Enable the access log:
+	loggedRouter := handlers.LoggingHandler(os.Stdout, mainRouter)
+
+	log.Fatal(http.ListenAndServe(serverAddress, loggedRouter))
 }
 
 // Close server


### PR DESCRIPTION
Currently the services generate their own simple access logs, each using a different mechanism. This patch changes them so that they log all requests, and using the same mechanism.