### PR TITLE
Don't ignore error in writeJSONResponse()

### DIFF
--- a/cmd/customers-service/handlers.go
+++ b/cmd/customers-service/handlers.go
@@ -94,7 +94,13 @@ func (server *Server) getCustomerByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeJSONResponse(w http.ResponseWriter, code int, payload interface{}) {
-	response, _ := json.Marshal(payload)
+	response, err := json.Marshal(payload)
+	if err != nil {
+		response, err = json.Marshal(map[string]string{"error": fmt.Sprint(err)})
+		if err != nil {
+			panic(fmt.Sprintf("error marshalling error: %v", err))
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	w.Write(response)


### PR DESCRIPTION
`writeJSONResponse()` ignores errors from `json.Marshal()`.  The only error situations I see in [documentation](https://golang.org/pkg/encoding/json/#Marshal) are:

> Channel, complex, and function values cannot be encoded in JSON. Attempting to encode such a value causes Marshal to return an UnsupportedTypeError.

Not a big problem for us but indeed `payload interface{}` could contain anything and we could accidentaly put there unsupported types.
It's more a matter of principle — as a rule we should not ignore errors, or we're cheating ourselves of the value (and cost) of coding in a language without exceptions!

In cases we never expect the error to happen, we can use the "must" idiom — call the function `mustWriteJSONResponse`, have it `panic()` on error.
Here, I decided even if unlikely we always want to respond 500 to client, not panic.
The 2nd "error marshalling error" should really never happen and could have been ignored but I'm making a point :-)  Plus, Elad wanted to add `errcheck` linter and we're not sure yet what's the convention to tell it — and more importantly human readers — where ignoring errors is deliberate...

@elad661 @jhernand please review.