### PR TITLE
customers-service: Removing etcd from template and adding psql

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -123,51 +123,6 @@ objects:
 - apiVersion: apps/v1beta1
   kind: Deployment
   metadata:
-    name: customers-db
-    labels:
-      app: customers-db
-  spec:
-    selector:
-      matchLabels:
-        app: customers-db
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          app: customers-db
-      spec:
-        volumes:
-        - name: data
-          emptyDir: {}
-        containers:
-        - name: etcd
-          image: quay.io/coreos/etcd:v3.1.11
-          imagePullPolicy: IfNotPresent
-          volumeMounts:
-          - name: data
-            mountPath: /var/lib/etcd
-          command:
-          - /usr/local/bin/etcd
-          - --data-dir=/var/lib/etcd
-          - --listen-client-urls=http://0.0.0.0:2379
-          - --advertise-client-urls=http://customers-db.${NAMESPACE}.svc.cluster.local:2379
-
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: customers-db
-    labels:
-      app: customers-db
-  spec:
-    selector:
-      app: customers-db
-    ports:
-    - port: 2379
-      targetPort: 2379
-
-- apiVersion: apps/v1beta1
-  kind: Deployment
-  metadata:
     name: customers-service
     labels:
       app: customers-service
@@ -187,7 +142,26 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
           - serve
-          - --etcd-endpoint=customers-db.${NAMESPACE}.svc.cluster.local:2379
+          - --sql-connection-string=host=localhost port=5432 user=service password=${PASSWORD} dbname=customers sslmode=disable
+        - name: postgresql
+          image: centos/postgresql-94-centos7
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: POSTGRESQL_DATABASE
+            value: clusters
+          - name: POSTGRESQL_USER
+            value: service
+          - name: POSTGRESQL_PASSWORD
+            value: ${PASSWORD}
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: data
+        volumes:
+        - emptyDir: {}
+          name: data
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
## What this does?
As continuation of removing etcd and adding psql - remove etcd pod and add psql as container in `customers-service` pod, similar to `clusters-service`.

cc: @cben @jhernand @yaacov 