### PR TITLE
customers-service: Return an error on Close

### DIFF
--- a/cmd/customers-service/customers_service.go
+++ b/cmd/customers-service/customers_service.go
@@ -37,7 +37,7 @@ type CustomersService interface {
 	Get(id string) (*Customer, error)
 
 	// Close closes the service.
-	Close()
+	Close() error
 }
 
 // ListArguments are arguments relevant for listing objects

--- a/cmd/customers-service/server.go
+++ b/cmd/customers-service/server.go
@@ -119,6 +119,6 @@ func runServe(cmd *cobra.Command, args []string) {
 }
 
 // Close server
-func (server *Server) Close() {
-	server.service.Close()
+func (server *Server) Close() error {
+	return server.service.Close()
 }

--- a/cmd/customers-service/sql_customers_service.go
+++ b/cmd/customers-service/sql_customers_service.go
@@ -46,8 +46,8 @@ func NewSQLCustomersService(connStr string) (*SQLCustomersService, error) {
 }
 
 // Close closes the sql customers service client.
-func (service *SQLCustomersService) Close() {
-	service.db.Close()
+func (service *SQLCustomersService) Close() error {
+	return service.db.Close()
 }
 
 // Add adds a single customer to psql database.


### PR DESCRIPTION
## What this does?
Return error upon `Close` method - such that `Service` and `Server` would implement `io.Closer` interface. 
cc: @cben @jhernand 