### PR TITLE
Remove `build.py` leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.gz
 *.log
 *.tar
-/.downloads/
-/.gopath/
 /vendor/
 build/
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,4 @@ fmt:
 
 .PHONY: clean
 clean:
-	rm -rf .gopath vendor *.tar *.tar.gz
+	rm -rf vendor *.tar *.tar.gz


### PR DESCRIPTION
This patch removes references to the `.gopath` directory that was used by the `build.py` script.