### PR TITLE
Do not crash on user input while serving http request

### DIFF
--- a/cmd/customers-service/handlers.go
+++ b/cmd/customers-service/handlers.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 )
 
@@ -96,10 +97,14 @@ func (server *Server) getCustomerByID(w http.ResponseWriter, r *http.Request) {
 func writeJSONResponse(w http.ResponseWriter, code int, payload interface{}) {
 	response, err := json.Marshal(payload)
 	if err != nil {
+		// If we can not marshal the payload, update response code and body.
+		glog.Errorf("Can't marshal json for response: %v", err)
+
 		response, err = json.Marshal(map[string]string{"error": fmt.Sprint(err)})
 		if err != nil {
-			panic(fmt.Sprintf("error marshalling error: %v", err))
+			response = []byte("{\"error\": \"can't marshal json for response\"}")
 		}
+		code = 500 // Internal server error code
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)

--- a/cmd/customers-service/sql_customers_service_test.go
+++ b/cmd/customers-service/sql_customers_service_test.go
@@ -113,12 +113,12 @@ func TestList(t *testing.T) {
 	deleteAll()
 
 	items := []*Customer{
-		&Customer{
+		{
 			ID:            "test-id0",
 			Name:          "test-name0",
 			OwnedClusters: []string{"test-cluster-id0", "test-cluster-id1"},
 		},
-		&Customer{
+		{
 			ID:            "test-id1",
 			Name:          "test-name1",
 			OwnedClusters: []string{"test-cluster-id2"},


### PR DESCRIPTION
### Description

Currently it is **theoretically** possible for an attacker to crash the service using crafted request.

**What happen**
An attacker creating a request that will get into line 101 will crash the server.

**What we want**
An attacker creating a malicious request will be logged, but not crash the service.


