### PR TITLE
API to retrieve cluster details

### DIFF
--- a/cmd/clusters-service/README.adoc
+++ b/cmd/clusters-service/README.adoc
@@ -1,0 +1,88 @@
+= Clusters Service
+This service provides a restful API to create and get _OpenShift_ clusters 
+
+== Get Clusters List
+
+[source]
+----
+$ curl  http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters
+{
+  "page": 0,
+  "size": 0,
+  "total": 0,
+  "items": []
+}
+----
+
+== Create a Cluster 
+create a file my_new_cluster.json
+[source]
+----
+{
+    "name": "myCluster",
+    "nodes": {
+        "master": 1,
+        "infra": 2,
+        "compute": 4
+    },
+    "memory": { 
+        "total": 400
+    },
+    "cpu": {
+        "total": 16
+    },
+    "storage": {
+        "total": 72
+    }
+}  
+$ curl -X POST -H "Content-Type: application/json" \
+  --data @my_new_cluster.json \ http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters 
+{
+  "id": "17YtAO99Xxd7AS25rPatEGrdX7d",
+  "name": "myCluster",
+  "nodes": {
+    "total": 7,
+    "master": 1,
+    "infra": 2,
+    "compute": 4
+  },
+  "memory": {
+    "total": 400
+  },
+  "cpu": {
+    "total": 16
+  },
+  "storage": {
+    "total": 72
+  }
+}
+----
+
+== Get Cluster Details
+[source]
+----
+curl  http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters/17YtAO99Xxd7AS25rPatEGrdX7d
+{
+  "id": "17YtAO99Xxd7AS25rPatEGrdX7d",
+  "name": "myCluster",
+  "nodes": {
+    "total": 7,
+    "master": 1,
+    "infra": 2,
+    "compute": 4
+  },
+  "memory": {
+    "total": 400
+  },
+  "cpu": {
+    "total": 16
+  },
+  "storage": {
+    "total": 72
+  }
+}
+----
+
+
+
+

--- a/cmd/clusters-service/handlers.go
+++ b/cmd/clusters-service/handlers.go
@@ -58,10 +58,10 @@ func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if spec.UUID != "" {
-		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "uuid must be empty"})
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "id must be empty"})
 		return
 	}
-	result, err := s.clusterService.Create(spec.Name)
+	result, err := s.clusterService.Create(spec)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/images/clusters-service/migrations/1530102892_add_cluster_details.down.sql
+++ b/images/clusters-service/migrations/1530102892_add_cluster_details.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE clusters
+DROP COLUMN name,
+DROP COLUMN master_nodes,
+DROP COLUMN infra_nodes, 
+DROP COLUMN compute_nodes, 
+DROP COLUMN memory, 
+DROP COLUMN cpu_cores,
+DROP COLUMN storage; 
+

--- a/images/clusters-service/migrations/1530102892_add_cluster_details.up.sql
+++ b/images/clusters-service/migrations/1530102892_add_cluster_details.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE clusters
+ADD COLUMN name text NOT NULL,
+ADD COLUMN master_nodes int,
+ADD COLUMN infra_nodes int, 
+ADD COLUMN compute_nodes int, 
+ADD COLUMN memory int, 
+ADD COLUMN cpu_cores int,
+ADD COLUMN storage int; 
+

--- a/images/clusters-service/migrations/1530102892_add_cluster_name.down.sql
+++ b/images/clusters-service/migrations/1530102892_add_cluster_name.down.sql
@@ -1,2 +1,0 @@
-ALTER TABLE clusters
-DROP COLUMN name;

--- a/images/clusters-service/migrations/1530102892_add_cluster_name.up.sql
+++ b/images/clusters-service/migrations/1530102892_add_cluster_name.up.sql
@@ -1,2 +1,0 @@
-ALTER TABLE clusters
-ADD COLUMN name text NOT NULL;


### PR DESCRIPTION
This PR updates the service API to include more details: nodes, memory, CPU, storage

Creation allows specifying total required resources.
Get will allow seeing the total and used resource.
At the moment, only total resource availability is implemented, as we still need to get the dynamic data (in a follow-up PR).

Also added service README with usage examples.