### PR TITLE
Always change to the `dedicated-portal` project

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
             done
 
             # Deploy the application:
-            oc ${OC_ARGS} new-project dedicated-portal || true
+            oc ${OC_ARGS} new-project dedicated-portal || oc ${OC_ARGS} project dedicated-portal || true
             oc ${OC_ARGS} process \
               --filename=template.yml \
               --param=NAMESPACE=dedicated-portal \

--- a/template.sh
+++ b/template.sh
@@ -20,7 +20,7 @@
 # the application.
 
 # Create the namespace:
-oc new-project dedicated-portal || true
+oc new-project dedicated-portal || oc project dedicated-portal || true
 
 # Use the template to create the objects:
 oc process \


### PR DESCRIPTION
Currently the `template.sh` script and the `Jenkinsfile` try to create the `dedicated-portal` project if it doesn't exist. But if the project already exists, and it isn't the current one, they don't make it the
current one, and as a result the objects may be created in other namespace. This patch changes both files so that if the creation of the project fails (because it already exists, most probably) they try to
make it the current one explicitly.