### PR TITLE
Fix err eq nil typo

### DIFF
--- a/cmd/customers-service/handlers.go
+++ b/cmd/customers-service/handlers.go
@@ -113,7 +113,7 @@ func writeJSONResponse(w http.ResponseWriter, code int, payload interface{}) {
 
 func responseWriterWriteWithLog(w http.ResponseWriter, msg []byte) {
 	_, err := w.Write(msg)
-	if err == nil {
+	if err != nil {
 		glog.Errorf("Write to client: %s", err)
 	}
 }


### PR DESCRIPTION
Fix typo from https://github.com/container-mgmt/dedicated-portal/pull/83

`err == nil` should be `err != nil`