### PR TITLE
Return the error creating cluster to the user

### DIFF
--- a/cmd/clusters-service/handlers.go
+++ b/cmd/clusters-service/handlers.go
@@ -63,7 +63,7 @@ func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := s.clusterService.Create(spec)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
 	}
 	writeJSONResponse(w, http.StatusCreated, result)


### PR DESCRIPTION
**Desccription**

In cluster service we usually return a json with some `error` string in case of internal error.
In the case of create  cluster we return empty string.

This PR return the error to the client in json form.