### PR TITLE
Adding ClusterDeployment using cluster-operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ go:
 go_import_path: github.com/container-mgmt/dedicated-portal
 
 install:
-- go get github.com/golang/dep/cmd/dep
+- wget https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64
+- echo 31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315 dep-linux-amd64 | sha256sum -c
+- mv dep-linux-amd64 ~/bin/dep
+- chmod +x ~/bin/dep
 - go get golang.org/x/lint/golint
 - go get github.com/client9/misspell/cmd/misspell
 - go get golang.org/x/tools/cmd/goimports

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,151 @@
 
 
 [[projects]]
+  branch = "default"
+  name = "bitbucket.org/ww/goautoneg"
+  packages = ["."]
+  revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+
+[[projects]]
+  name = "github.com/NYTimes/gziphandler"
+  packages = ["."]
+  revision = "2600fb119af974220d3916a5916d6e31176aac1b"
+  version = "v1.0.1"
+
+[[projects]]
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
   branch = "master"
   name = "github.com/auth0/go-jwt-middleware"
   packages = ["."]
   revision = "5493cabe49f7bfa6e2ec444a09d334d90cd4e2bd"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  name = "github.com/coreos/etcd"
+  packages = [
+    "auth/authpb",
+    "client",
+    "clientv3",
+    "etcdserver/api/v3rpc/rpctypes",
+    "etcdserver/etcdserverpb",
+    "mvcc/mvccpb",
+    "pkg/pathutil",
+    "pkg/srv",
+    "pkg/tlsutil",
+    "pkg/transport",
+    "pkg/types",
+    "version"
+  ]
+  revision = "33245c6b5b49130ca99280408fadfab01aac0e48"
+  version = "v3.3.8"
+
+[[projects]]
+  name = "github.com/coreos/go-semver"
+  packages = ["semver"]
+  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
+  version = "v0.2.0"
+
+[[projects]]
+  name = "github.com/coreos/go-systemd"
+  packages = ["daemon"]
+  revision = "39ca1b05acc7ad1220e09f133283b8859a8b71ab"
+  version = "v17"
+
+[[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
+
+[[projects]]
+  name = "github.com/elazarl/go-bindata-assetfs"
+  packages = ["."]
+  revision = "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/emicklei/go-restful"
+  packages = [
+    ".",
+    "log"
+  ]
+  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
+  version = "v2.8.0"
+
+[[projects]]
+  name = "github.com/emicklei/go-restful-swagger12"
+  packages = ["."]
+  revision = "dcef7f55730566d41eae5db10e7d6981829720f6"
+  version = "1.0.1"
+
+[[projects]]
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
+  version = "v3.0.0"
+
+[[projects]]
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
+  version = "0.15.0"
+
+[[projects]]
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
+  version = "0.15.0"
+
+[[projects]]
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
+  version = "0.15.0"
+
+[[projects]]
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
+  version = "0.15.0"
+
+[[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor",
+    "sortkeys"
+  ]
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/golang-migrate/migrate"
@@ -22,13 +157,47 @@
     "source",
     "source/file"
   ]
-  revision = "bcd996f3df28363f43e2d0935484c4559537a3eb"
-  version = "v3.3.0"
+  revision = "6bb3e494e544a6bba307308388e641393e7b4767"
+  version = "v3.3.1"
 
 [[projects]]
   name = "github.com/golang/glog"
   packages = ["."]
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/btree"
+  packages = ["."]
+  revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  name = "github.com/googleapis/gnostic"
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions"
+  ]
+  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
+  version = "v0.2.0"
 
 [[projects]]
   name = "github.com/gorilla/context"
@@ -49,10 +218,58 @@
   version = "v1.6.2"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache"
+  ]
+  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru"
+  ]
+  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/howeyc/gopass"
+  packages = ["."]
+  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+
+[[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
+  version = "v0.3.5"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
+  version = "1.1.4"
+
+[[projects]]
+  name = "github.com/juju/ratelimit"
+  packages = ["."]
+  revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
+  version = "1.0.1"
+
+[[projects]]
+  name = "github.com/kubernetes-incubator/apiserver-builder"
+  packages = ["pkg/builders"]
+  revision = "14201e804a58a140011a0044b15331f477535f91"
+  version = "v1.9-alpha.4"
 
 [[projects]]
   branch = "master"
@@ -62,6 +279,103 @@
     "oid"
   ]
   revision = "90697d60dd844d5ef6ff15135d0203f65d2f53b8"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
+  revision = "efc7eb8984d6655c26b5c9d2e65c024e5767c37c"
+
+[[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mxk/go-flowrate"
+  packages = ["flowrate"]
+  revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/openshift/cluster-operator"
+  packages = [
+    "pkg/apis/clusteroperator",
+    "pkg/apis/clusteroperator/v1alpha1",
+    "pkg/client/clientset_generated/clientset",
+    "pkg/client/clientset_generated/clientset/scheme",
+    "pkg/client/clientset_generated/clientset/typed/clusteroperator/v1alpha1"
+  ]
+  revision = "0f9f88a4650a4c665a6f57135700e005e605e1cc"
+
+[[projects]]
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
+  version = "v1.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+
+[[projects]]
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
+  version = "v2.0.1"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = ["prometheus"]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
   name = "github.com/segmentio/ksuid"
@@ -82,14 +396,448 @@
   version = "v1.0.1"
 
 [[projects]]
+  name = "github.com/ugorji/go"
+  packages = ["codec"]
+  revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
+  version = "v1.1.1"
+
+[[projects]]
   name = "github.com/urfave/negroni"
   packages = ["."]
   revision = "5dbbc83f748fc3ad38585842b0aedab546d0ea1e"
   version = "v0.3.0"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "a2144134853fc9a27a7b1e3eb4f19f1a76df13c9"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "html",
+    "html/atom",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+    "websocket"
+  ]
+  revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "ac767d655b305d4e9612f5f6e33120b9176c4ad4"
+
+[[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  revision = "fedd2861243fd1a8152376292b921b394c7bef7e"
+
+[[projects]]
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "health/grpc_health_v1",
+    "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/grpcrand",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
+  revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
+  version = "v1.13.0"
+
+[[projects]]
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
+[[projects]]
+  name = "k8s.io/api"
+  packages = [
+    "admission/v1beta1",
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1"
+  ]
+  revision = "af4bc157c3a209798fc897f6d4aaaaeb6c2e0d6a"
+  version = "kubernetes-1.9.0"
+
+[[projects]]
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/equality",
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/api/validation",
+    "pkg/api/validation/path",
+    "pkg/apimachinery",
+    "pkg/apimachinery/announced",
+    "pkg/apimachinery/registered",
+    "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/validation",
+    "pkg/apis/meta/v1alpha1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/mergepatch",
+    "pkg/util/net",
+    "pkg/util/proxy",
+    "pkg/util/rand",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/strategicpatch",
+    "pkg/util/uuid",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/waitgroup",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/json",
+    "third_party/forked/golang/netutil",
+    "third_party/forked/golang/reflect"
+  ]
+  revision = "180eddb345a5be3a157cea1c624700ad5bd27b8f"
+  version = "kubernetes-1.9.0"
+
+[[projects]]
+  name = "k8s.io/apiserver"
+  packages = [
+    "pkg/admission",
+    "pkg/admission/configuration",
+    "pkg/admission/initializer",
+    "pkg/admission/metrics",
+    "pkg/admission/plugin/initialization",
+    "pkg/admission/plugin/namespace/lifecycle",
+    "pkg/admission/plugin/webhook/config",
+    "pkg/admission/plugin/webhook/config/apis/webhookadmission",
+    "pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1",
+    "pkg/admission/plugin/webhook/errors",
+    "pkg/admission/plugin/webhook/mutating",
+    "pkg/admission/plugin/webhook/namespace",
+    "pkg/admission/plugin/webhook/request",
+    "pkg/admission/plugin/webhook/rules",
+    "pkg/admission/plugin/webhook/validating",
+    "pkg/admission/plugin/webhook/versioned",
+    "pkg/apis/apiserver",
+    "pkg/apis/apiserver/install",
+    "pkg/apis/apiserver/v1alpha1",
+    "pkg/apis/audit",
+    "pkg/apis/audit/v1alpha1",
+    "pkg/apis/audit/v1beta1",
+    "pkg/apis/audit/validation",
+    "pkg/audit",
+    "pkg/audit/policy",
+    "pkg/authentication/authenticator",
+    "pkg/authentication/authenticatorfactory",
+    "pkg/authentication/group",
+    "pkg/authentication/request/anonymous",
+    "pkg/authentication/request/bearertoken",
+    "pkg/authentication/request/headerrequest",
+    "pkg/authentication/request/union",
+    "pkg/authentication/request/websocket",
+    "pkg/authentication/request/x509",
+    "pkg/authentication/serviceaccount",
+    "pkg/authentication/token/tokenfile",
+    "pkg/authentication/user",
+    "pkg/authorization/authorizer",
+    "pkg/authorization/authorizerfactory",
+    "pkg/authorization/union",
+    "pkg/endpoints",
+    "pkg/endpoints/discovery",
+    "pkg/endpoints/filters",
+    "pkg/endpoints/handlers",
+    "pkg/endpoints/handlers/negotiation",
+    "pkg/endpoints/handlers/responsewriters",
+    "pkg/endpoints/metrics",
+    "pkg/endpoints/openapi",
+    "pkg/endpoints/request",
+    "pkg/features",
+    "pkg/registry/generic",
+    "pkg/registry/generic/registry",
+    "pkg/registry/rest",
+    "pkg/server",
+    "pkg/server/filters",
+    "pkg/server/healthz",
+    "pkg/server/httplog",
+    "pkg/server/mux",
+    "pkg/server/routes",
+    "pkg/server/routes/data/swagger",
+    "pkg/storage",
+    "pkg/storage/errors",
+    "pkg/storage/etcd",
+    "pkg/storage/etcd/metrics",
+    "pkg/storage/etcd/util",
+    "pkg/storage/etcd3",
+    "pkg/storage/names",
+    "pkg/storage/storagebackend",
+    "pkg/storage/storagebackend/factory",
+    "pkg/storage/value",
+    "pkg/util/feature",
+    "pkg/util/flushwriter",
+    "pkg/util/trace",
+    "pkg/util/webhook",
+    "pkg/util/wsstream",
+    "plugin/pkg/authenticator/token/webhook",
+    "plugin/pkg/authorizer/webhook"
+  ]
+  revision = "91e14f394e4796abf5a994a349a222e7081d86b6"
+  version = "kubernetes-1.9.0"
+
+[[projects]]
+  name = "k8s.io/client-go"
+  packages = [
+    "discovery",
+    "informers",
+    "informers/admissionregistration",
+    "informers/admissionregistration/v1alpha1",
+    "informers/admissionregistration/v1beta1",
+    "informers/apps",
+    "informers/apps/v1",
+    "informers/apps/v1beta1",
+    "informers/apps/v1beta2",
+    "informers/autoscaling",
+    "informers/autoscaling/v1",
+    "informers/autoscaling/v2beta1",
+    "informers/batch",
+    "informers/batch/v1",
+    "informers/batch/v1beta1",
+    "informers/batch/v2alpha1",
+    "informers/certificates",
+    "informers/certificates/v1beta1",
+    "informers/core",
+    "informers/core/v1",
+    "informers/events",
+    "informers/events/v1beta1",
+    "informers/extensions",
+    "informers/extensions/v1beta1",
+    "informers/internalinterfaces",
+    "informers/networking",
+    "informers/networking/v1",
+    "informers/policy",
+    "informers/policy/v1beta1",
+    "informers/rbac",
+    "informers/rbac/v1",
+    "informers/rbac/v1alpha1",
+    "informers/rbac/v1beta1",
+    "informers/scheduling",
+    "informers/scheduling/v1alpha1",
+    "informers/settings",
+    "informers/settings/v1alpha1",
+    "informers/storage",
+    "informers/storage/v1",
+    "informers/storage/v1alpha1",
+    "informers/storage/v1beta1",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "listers/admissionregistration/v1alpha1",
+    "listers/admissionregistration/v1beta1",
+    "listers/apps/v1",
+    "listers/apps/v1beta1",
+    "listers/apps/v1beta2",
+    "listers/autoscaling/v1",
+    "listers/autoscaling/v2beta1",
+    "listers/batch/v1",
+    "listers/batch/v1beta1",
+    "listers/batch/v2alpha1",
+    "listers/certificates/v1beta1",
+    "listers/core/v1",
+    "listers/events/v1beta1",
+    "listers/extensions/v1beta1",
+    "listers/networking/v1",
+    "listers/policy/v1beta1",
+    "listers/rbac/v1",
+    "listers/rbac/v1alpha1",
+    "listers/rbac/v1beta1",
+    "listers/scheduling/v1alpha1",
+    "listers/settings/v1alpha1",
+    "listers/storage/v1",
+    "listers/storage/v1alpha1",
+    "listers/storage/v1beta1",
+    "pkg/version",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/cache",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/pager",
+    "tools/reference",
+    "transport",
+    "util/buffer",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer"
+  ]
+  revision = "78700dec6369ba22221b72770783300f143df150"
+  version = "v6.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/kube-openapi"
+  packages = [
+    "pkg/builder",
+    "pkg/common",
+    "pkg/handler",
+    "pkg/util",
+    "pkg/util/proto"
+  ]
+  revision = "d8ea2fe547a448256204cfc68dfee7b26c720acb"
+
+[[projects]]
+  name = "sigs.k8s.io/cluster-api"
+  packages = [
+    "pkg/apis/cluster",
+    "pkg/apis/cluster/common",
+    "pkg/apis/cluster/v1alpha1"
+  ]
+  revision = "fbc85d97affbf5c9ad97054c66b23ad2bc0ca097"
+  version = "0.0.0-alpha.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cb134df4749fb5c0b79d368f76044cd63b1d37d7b183eae11be0fa148bbedb02"
+  inputs-digest = "463188a483f19cc27d6cbc281a345fe6da257da0c2f9117a14d136edb6f04d04"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,3 +42,26 @@
 [[constraint]]
   name = "github.com/dgrijalva/jwt-go"
   version = "v3.2.0"
+
+[[constraint]]
+  name = "github.com/openshift/cluster-operator"
+  branch = "master"
+
+[[constraint]]
+  name = "k8s.io/client-go"
+  version = "kubernetes-1.9.0"
+
+[[override]]
+  name = "k8s.io/api"
+  version = "kubernetes-1.9.0"
+[[override]]
+  name = "k8s.io/apiserver"
+  version = "kubernetes-1.9.0"
+
+[[override]]
+  name = "k8s.io/apimachinery"
+  version = "kubernetes-1.9.0"
+
+[[override]]
+  name = "k8s.io/kubernetes"
+  version = "kubernetes-1.9.0"

--- a/cmd/clusters-service/README.adoc
+++ b/cmd/clusters-service/README.adoc
@@ -1,5 +1,5 @@
 = Clusters Service
-This service provides a restful API to create and get _OpenShift_ clusters 
+This service provides a restful API to create and get _OpenShift_ clusters
 
 == Get Clusters List
 
@@ -14,7 +14,7 @@ $ curl  http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters
 }
 ----
 
-== Create a Cluster 
+== Create a Cluster
 create a file my_new_cluster.json
 [source]
 ----
@@ -25,7 +25,7 @@ create a file my_new_cluster.json
         "infra": 2,
         "compute": 4
     },
-    "memory": { 
+    "memory": {
         "total": 400
     },
     "cpu": {
@@ -34,9 +34,9 @@ create a file my_new_cluster.json
     "storage": {
         "total": 72
     }
-}  
+}
 $ curl -X POST -H "Content-Type: application/json" \
-  --data @my_new_cluster.json \ http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters 
+  --data @my_new_cluster.json \ http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters
 {
   "id": "17YtAO99Xxd7AS25rPatEGrdX7d",
   "name": "myCluster",
@@ -83,6 +83,21 @@ curl  http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters/17Y
 }
 ----
 
-
-
-
+== How to use cluster-operator along side cluster-service
+Currently, there is no deployment for cluster-operator alongside cluster-service.
+To deploy cluster-operator follow the one-time setup instructions under https://github.com/openshift/cluster-operator:
+[source]
+----
+# deploy dedicated-portal.
+./hack/cluster-restart.sh
+# login as admin
+oc login -u system:admin
+# give permissions for dedicated portal to create k8s resources.
+oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:dedicated-portal:default
+# create a user with admin permissions and switch to it.
+oc adm policy add-cluster-role-to-user cluster-admin admin
+# login to admin user
+oc login -u admin -p password
+# deploy cluster-operator from ansible (fake deployment. for real deployment add `-e fake_deployment=false` flag)
+ansible-playbook contrib/ansible/deploy-devel-playbook.yml
+----

--- a/cmd/clusters-service/cluster_provisioner.go
+++ b/cmd/clusters-service/cluster_provisioner.go
@@ -1,0 +1,291 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/container-mgmt/dedicated-portal/pkg/api"
+
+	v1alpha1 "github.com/openshift/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
+	clientset "github.com/openshift/cluster-operator/pkg/client/clientset_generated/clientset"
+	corev1 "k8s.io/api/core/v1"
+	errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8s "k8s.io/client-go/kubernetes"
+	scheme "k8s.io/client-go/kubernetes/scheme"
+	rest "k8s.io/client-go/rest"
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// ClusterProvisioner is the interface used by cluster service to
+// provision clusters.
+type ClusterProvisioner interface {
+	Provision(spec api.Cluster) error
+}
+
+// ClusterOperatorProvisioner is the struct implementing ClusterProvisioner
+// using Cluster Operator.
+type ClusterOperatorProvisioner struct {
+	clusterOperatorClient *clientset.Clientset
+	k8sClient             *k8s.Clientset
+}
+
+const clusterNameSpace = "dedicated-portal"
+
+// NewClusterOperatorProvisioner A constructor for ClusterOperatorProvisioner struct.
+func NewClusterOperatorProvisioner(k8sConfig *rest.Config) (*ClusterOperatorProvisioner, error) {
+	metav1.AddToGroupVersion(scheme.Scheme, schema.GroupVersion{Version: "v1"})
+	// Register ClusterDeployment, ClusterVersion, and other CRD's to k8s scheme.
+	err := v1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("An error occurred trying to add ClusterDeployment to scheme: %s", err)
+	}
+	clusterOperatorClient, err := clientset.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create cluster operator client: %s", err)
+	}
+	k8sClient, err := k8s.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create kubernetes client: %s", err)
+	}
+	return &ClusterOperatorProvisioner{
+		clusterOperatorClient: clusterOperatorClient,
+		k8sClient:             k8sClient,
+	}, nil
+}
+
+// Provision provisions a cluster on aws using cluster operator.
+func (provisioner *ClusterOperatorProvisioner) Provision(spec api.Cluster) error {
+	// Create secrets.
+	err := provisioner.createSecrets(spec)
+	if err != nil {
+		return fmt.Errorf("Failed to create secrets: %s", err)
+	}
+	// Create cluster version object.
+	err = provisioner.createClusterVersionIfNotExist(spec)
+	if err != nil {
+		return fmt.Errorf("Failed to create ClusterVersion object: %s", err)
+	}
+	// Create the cluster deployment custom resource
+	clusterDeployment := provisioner.clusterDeploymentFromSpec(spec)
+	_, err = provisioner.clusterOperatorClient.
+		ClusteroperatorV1alpha1().
+		ClusterDeployments(clusterNameSpace).
+		Create(&clusterDeployment)
+	if err != nil {
+		return fmt.Errorf("Failed to create ClusterDeployment object: %s", err)
+	}
+	return nil
+}
+
+func (provisioner *ClusterOperatorProvisioner) clusterDeploymentFromSpec(spec api.Cluster) v1alpha1.ClusterDeployment {
+	clusterName := strings.ToLower(spec.Name)
+	clusterDeploymentSpec := v1alpha1.ClusterDeploymentSpec{
+		ClusterName: clusterName,
+		ClusterVersionRef: v1alpha1.ClusterVersionReference{
+			Name:      "origin-v3-10",
+			Namespace: clusterNameSpace,
+		},
+		NetworkConfig: capiv1.ClusterNetworkingConfig{
+			Services: capiv1.NetworkRanges{
+				CIDRBlocks: []string{"172.30.0.0/16"},
+			},
+			Pods: capiv1.NetworkRanges{
+				CIDRBlocks: []string{"172.30.0.0/14"},
+			},
+		},
+		Hardware: v1alpha1.ClusterHardwareSpec{
+			AWS: &v1alpha1.AWSClusterSpec{
+				AccountSecret: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("%s-aws-creds", clusterName),
+				},
+				SSHSecret: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("%s-ssh-key", clusterName),
+				},
+				SSHUser: "centos",
+				SSLSecret: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("%s-certs", clusterName),
+				},
+				Region:      "us-east-1",
+				KeyPairName: "libra",
+			},
+		},
+		DefaultHardwareSpec: &v1alpha1.MachineSetHardwareSpec{
+			AWS: &v1alpha1.MachineSetAWSHardwareSpec{
+				InstanceType: "t2.xlarge",
+			},
+		},
+		MachineSets: provisioner.machineSetsFromSpec(spec),
+	}
+	clusterDeployment := v1alpha1.ClusterDeployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "clusteroperator.openshift.io/v1alpha1",
+			Kind:       "ClusterDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: clusterNameSpace,
+		},
+		Spec: clusterDeploymentSpec,
+	}
+	return clusterDeployment
+}
+
+func (provisioner *ClusterOperatorProvisioner) machineSetsFromSpec(spec api.Cluster) []v1alpha1.ClusterMachineSet {
+	infra := v1alpha1.ClusterMachineSet{
+		ShortName: "infra",
+		MachineSetConfig: v1alpha1.MachineSetConfig{
+			Infra:    true,
+			Size:     spec.Nodes.Infra,
+			NodeType: v1alpha1.NodeTypeCompute,
+		},
+	}
+	compute := v1alpha1.ClusterMachineSet{
+		ShortName: "compute",
+		MachineSetConfig: v1alpha1.MachineSetConfig{
+			Infra:    false,
+			Size:     spec.Nodes.Compute,
+			NodeType: v1alpha1.NodeTypeCompute,
+		},
+	}
+	master := v1alpha1.ClusterMachineSet{
+		MachineSetConfig: v1alpha1.MachineSetConfig{
+			Infra:    false,
+			Size:     spec.Nodes.Master,
+			NodeType: v1alpha1.NodeTypeMaster,
+		},
+	}
+	return []v1alpha1.ClusterMachineSet{master, compute, infra}
+}
+
+func (provisioner *ClusterOperatorProvisioner) createClusterVersionIfNotExist(spec api.Cluster) error {
+	clusterVersionName := "origin-v3-10"
+	clusterVersion := v1alpha1.ClusterVersion{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "clusteroperator.openshift.io/v1alpha1",
+			Kind:       "ClusterVersion",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterVersionName,
+			Namespace: clusterNameSpace,
+		},
+		Spec: v1alpha1.ClusterVersionSpec{
+			DeploymentType: v1alpha1.ClusterDeploymentTypeOrigin,
+			Version:        "v3.10.0",
+			VMImages: v1alpha1.VMImages{
+				AWSImages: &v1alpha1.AWSVMImages{
+					RegionAMIs: []v1alpha1.AWSRegionAMIs{
+						{
+							Region: "us-east-1",
+							AMI:    "ami-0dd8ad483cef75c18",
+						},
+					},
+				},
+			},
+			Images: v1alpha1.ClusterVersionImages{
+				ImageFormat: "openshift/origin-${component}:v3.10.0",
+			},
+		},
+	}
+
+	// Attempt to retrieve ClusterVersion object.
+	_, err := provisioner.clusterOperatorClient.
+		ClusteroperatorV1alpha1().
+		ClusterVersions(clusterNameSpace).
+		Get(clusterVersionName, metav1.GetOptions{})
+
+	// If ClusterVersion does not exit - create it;
+	// Otherwise, return.
+	if errors.IsNotFound(err) {
+		_, err = provisioner.clusterOperatorClient.
+			ClusteroperatorV1alpha1().
+			ClusterVersions(clusterNameSpace).
+			Create(&clusterVersion)
+		if err != nil {
+			return err
+		}
+	} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+		return fmt.Errorf("Error getting cluster version %s in namespace %s: %v",
+			clusterVersionName, clusterNameSpace, statusError.ErrStatus.Message)
+	} else if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (provisioner *ClusterOperatorProvisioner) createSecrets(spec api.Cluster) error {
+	secrets := []*corev1.Secret{
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNameSpace,
+				Name:      fmt.Sprintf("%s-certs", strings.ToLower(spec.Name)),
+			},
+			Type: "Opaque",
+			Data: map[string][]byte{
+				"server.crt": []byte("fake_tls_cert"),
+				"server.key": []byte("fake_tls_key"),
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNameSpace,
+				Name:      fmt.Sprintf("%s-aws-creds", strings.ToLower(spec.Name)),
+			},
+			Type: "Opaque",
+			Data: map[string][]byte{
+				"awsAccessKeyId":     []byte("fake_aws_access_key_id"),
+				"awsSecretAccessKey": []byte("fake_aws_secrete_access_key"),
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNameSpace,
+				Name:      fmt.Sprintf("%s-ssh-key", strings.ToLower(spec.Name)),
+			},
+			Type: "Opaque",
+			Data: map[string][]byte{
+				"ssh-privatekey": []byte("fake_ssh_private_key"),
+				"ssh-publickey":  []byte("fake_ssh_public_key"),
+			},
+		},
+	}
+	// Create secretes
+	for _, secret := range secrets {
+		_, err := provisioner.k8sClient.CoreV1().
+			Secrets(clusterNameSpace).
+			Create(secret)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/container-mgmt/dedicated-portal/pkg/signals"
 	"github.com/container-mgmt/dedicated-portal/pkg/sql"
@@ -11,6 +12,9 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 )
 
 var serveArgs struct {
@@ -23,6 +27,11 @@ var serveCmd = &cobra.Command{
 	Long:  "Serve the clusters service service.",
 	Run:   runServe,
 }
+
+var (
+	clusterOperatorKubeAddress string
+	clusterOperatorKubeConfig  string
+)
 
 // Server serves HTTP API requests on clusters.
 type Server struct {
@@ -66,7 +75,28 @@ func (s Server) start() error {
 	return nil
 }
 
-func runServe(*cobra.Command, []string) {
+func init() {
+	serveFlags := serveCmd.Flags()
+	serveFlags.StringVar(
+		&clusterOperatorKubeConfig,
+		"cluster-operator-kubeconfig",
+		"",
+		"Path to a Kubernetes client configuration file used to connect "+
+			"to the cluster where the cluster operator is running. Only required when running "+
+			"cluster-operator outside of the cluster where the clusters-service is running. .",
+	)
+	serveFlags.StringVar(
+		&clusterOperatorKubeAddress,
+		"cluster-operator-master",
+		"",
+		"The address of the Kubernetes API server for the cluster where cluster operator is running."+
+			"Overrides any value in the Kubernetes "+
+			"configuration file. Only required when running cluster-operator outside of the cluster "+
+			"where the clusters-service is running.",
+	)
+}
+
+func runServe(cmd *cobra.Command, args []string) {
 	// Set up signals so we handle the first shutdown signal gracefully:
 	stopCh := signals.SetupHandler()
 
@@ -76,7 +106,13 @@ func runServe(*cobra.Command, []string) {
 		os.Exit(1)
 	}
 
-	err := sql.EnsureSchema(
+	k8sConfig, err := retrieveKubeConfig()
+
+	if err != nil {
+		glog.Fatalf("An error occurred while trying to retrieve kubernetes configurations: %s", err)
+	}
+
+	err = sql.EnsureSchema(
 		"/usr/local/share/clusters-service/migrations",
 		serveArgs.dbURL,
 	)
@@ -84,17 +120,97 @@ func runServe(*cobra.Command, []string) {
 		glog.Errorf("can't run sql migration: %s", err)
 		os.Exit(1)
 	}
-	service := NewClustersService(serveArgs.dbURL)
+
+	provisioner, err := NewClusterOperatorProvisioner(k8sConfig)
+	if err != nil {
+		panic(fmt.Sprintf("Error starting clusters service: %v", err))
+	}
+
+	service := NewClustersService(serveArgs.dbURL, provisioner)
 	fmt.Println("Created cluster service.")
 
-	// This is temporary and should be replaced with reading from the queue
 	server := NewServer(stopCh, service)
 	err = server.start()
 	if err != nil {
 		panic(fmt.Sprintf("Error starting server: %v", err))
 	}
+
 	fmt.Println("Created server.")
 
 	fmt.Println("Waiting for stop signal")
 	<-stopCh // wait until requested to stop.
+}
+
+func retrieveKubeConfig() (*rest.Config, error) {
+	// Load the Kubernetes configuration:
+	var k8sConfig *rest.Config
+
+	kubeConfig, err := kubeConfigPath(clusterOperatorKubeConfig)
+	if err == nil {
+		// If error is nil, we have a valid kubeConfig file:
+		k8sConfig, err = clientcmd.BuildConfigFromFlags(clusterOperatorKubeAddress, kubeConfig)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error loading REST client configuration from file '%s': %s",
+				kubeConfig, err,
+			)
+		}
+
+		return k8sConfig, nil
+
+	} else if kubeConfig == "" {
+		// If kubeConfig is "", file is missing, in this case we will
+		// try to use in-cluster configuration.
+		glog.Info("Try to use the in-cluster configuration")
+		k8sConfig, err = rest.InClusterConfig()
+		// Catch in-cluster configuration error:
+		if err != nil {
+			return nil, fmt.Errorf("Error loading in-cluster REST client configuration: %s", err)
+		}
+
+		return k8sConfig, nil
+
+	} else {
+		// Catch all errors:
+		return nil, fmt.Errorf("Error: %s", err)
+	}
+}
+
+func kubeConfigPath(clusterOperatorKubeConfig string) (kubeConfig string, err error) {
+	// The loading order follows these rules:
+	// 1. If the –kubeconfig flag is set,
+	// then only that file is loaded. The flag may only be set once.
+	// 2. If $KUBECONFIG environment variable is set, use it.
+	// 3. Otherwise, ${HOME}/.kube/config is used.
+	var ok bool
+
+	// Get the config file path
+	if clusterOperatorKubeConfig != "" {
+		kubeConfig = clusterOperatorKubeConfig
+	} else {
+		if kubeConfig, ok = os.LookupEnv("KUBECONFIG"); ok != true {
+			kubeConfig = filepath.Join(homedir.HomeDir(), ".kube", "config")
+		}
+	}
+
+	// Check config file:
+	fInfo, err := os.Stat(kubeConfig)
+	if os.IsNotExist(err) {
+		// NOTE: If config file does not exist, assume using pod configuration.
+		err = fmt.Errorf("The Kubernetes configuration file '%s' doesn't exist", kubeConfig)
+		kubeConfig = ""
+		return
+	}
+
+	// Check error codes.
+	if fInfo.IsDir() {
+		err = fmt.Errorf("The Kubernetes configuration path '%s' is a direcory", kubeConfig)
+		return
+	}
+	if os.IsPermission(err) {
+		err = fmt.Errorf("Can't open Kubernetes configuration file '%s'", kubeConfig)
+		return
+	}
+
+	return
 }


### PR DESCRIPTION
This is a **work in progress** pushed for transparency purposes.

## What this does?
~~Adds ClusterDeployment struct~~ Allowing cluster-service to create a k8s custom resource ClusterDeployment struct which will then be used by CO to create actual machines.

Todo:

- [ ] Ensure CO is running on kubernetes.

- [ ] Create custom namespace ~~for user~~ per cluster.

- [x] Create the cluster deployment custom resource using code from CO.

- [x] Add the custom resource to k8s.

- [ ] Check machine status to make sure their actoually created. (usually take a couple of minutes)

cc: @jhernand @cben  @oourfali 

![peek 2018-07-22 22-25](https://user-images.githubusercontent.com/8366181/43049518-d8dc420c-8e01-11e8-8f9c-a32e6a29820c.gif)
