### PR TITLE
Check user id before answering requests

### DIFF
--- a/cmd/customers-service/service/sql_customers_service.go
+++ b/cmd/customers-service/service/sql_customers_service.go
@@ -109,7 +109,7 @@ func (s *SQLCustomersService) Get(id string) (*Customer, error) {
 	// (See customers_service.go for more details)
 	rows, err := s.db.Query(`select name from customers where id=$1`, id)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	for rows.Next() {


### PR DESCRIPTION
**Description**

Currently we only check that the token is valid.

This PR adds check that the token subject match the request user id.

**Terminal dump**

Bad user ID
``` bash
$ curl -s http://localhost:8000/api/customers_mgmt/v1/customers/BAD_USER_ID -H "authorization: Bearer $TOKEN"| jq
{
  "error": "user id does not match token"
}
```

Currect user ID
[ I do not have a postgres server running -  pq: Ident authentication failed for user \"postgres\"]
``` bash
$ curl -s http://localhost:8000/api/customers_mgmt/v1/customers/924fea...2f0b -H "authorization: Bearer $TOKEN"| jq
{
  "error": "Error getting customer, pq: Ident authentication failed for user \"postgres\""
}
```





