### PR TITLE
hack/cluster-restart.sh: Don't require running from project root

### DIFF
--- a/hack/cluster-restart.sh
+++ b/hack/cluster-restart.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+cd "$(dirname "$0")"/..
+
 oc cluster down
 make images
 oc cluster up


### PR DESCRIPTION
A small tweak to allow running `hack/cluster-restart.sh` from any working directory.