### PR TITLE
Move API types to `api` package

### DIFF
--- a/cmd/clusters-service/handlers.go
+++ b/cmd/clusters-service/handlers.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
+
+	"github.com/container-mgmt/dedicated-portal/pkg/api"
 )
 
 func (s Server) listClusters(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +53,7 @@ func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
 	}
-	var spec Cluster
+	var spec api.Cluster
 	err = json.Unmarshal(bytes, &spec)
 	if err != nil {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})

--- a/cmd/customers-service/handlers.go
+++ b/cmd/customers-service/handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/container-mgmt/dedicated-portal/cmd/customers-service/service"
+	"github.com/container-mgmt/dedicated-portal/pkg/api"
 	"github.com/container-mgmt/dedicated-portal/pkg/auth"
 )
 
@@ -50,7 +51,7 @@ func (server *Server) Close() error {
 }
 
 func (server *Server) getCustomersList(w http.ResponseWriter, r *http.Request) {
-	var ret *service.CustomersList
+	var ret *api.CustomerList
 	var err error
 	var page int64
 	var size int64
@@ -91,7 +92,7 @@ func (server *Server) getCustomersList(w http.ResponseWriter, r *http.Request) {
 
 func (server *Server) addCustomer(w http.ResponseWriter, r *http.Request) {
 	decoder := json.NewDecoder(r.Body)
-	var customer service.Customer
+	var customer api.Customer
 
 	// Check token authorization
 	if _, err := auth.CheckToken(w, r); err != nil {
@@ -115,7 +116,7 @@ func (server *Server) addCustomer(w http.ResponseWriter, r *http.Request) {
 
 func (server *Server) getCustomerByID(w http.ResponseWriter, r *http.Request) {
 	var sub string
-	var ret *service.Customer
+	var ret *api.Customer
 	var err error
 
 	id := mux.Vars(r)["id"]

--- a/cmd/customers-service/service/customers_service.go
+++ b/cmd/customers-service/service/customers_service.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package service
 
+import (
+	"github.com/container-mgmt/dedicated-portal/pkg/api"
+)
+
 // CustomersService is an interface exposing a set of operations required for
 // running and operating the customers of the Openshift Dedicated Portal.
 type CustomersService interface {
@@ -23,18 +27,18 @@ type CustomersService interface {
 	// List returns a pointer to CustomerList or error in case some error occurred.
 	// If list arguments are provided list will return the intended customers list.
 	// If nil is supplied list will return all customers.
-	List(args *ListArguments) (*CustomersList, error)
+	List(args *ListArguments) (*api.CustomerList, error)
 
 	// Add creates a customer and returns the newly created customer or error
 	// in case some error occurred.
 	// It receives a Customer object with its Name and (possibly) OwnedClusters,
 	// and creates a new Customer based on the supplied Customer parameter.
-	Add(customer Customer) (*Customer, error)
+	Add(customer api.Customer) (*api.Customer, error)
 
 	// Get returns a pointer to customer with id supplied or error if an
 	// error occurred.
 	// If no such customer exist Get returns nil pointer and nil error.
-	Get(id string) (*Customer, error)
+	Get(id string) (*api.Customer, error)
 
 	// Close closes the service.
 	Close() error

--- a/cmd/customers-service/service/demo_customers_service.go
+++ b/cmd/customers-service/service/demo_customers_service.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package service
 
+import (
+	"github.com/container-mgmt/dedicated-portal/pkg/api"
+)
+
 // DemoCustomersService is a struct implementing the customer service interface.
 type DemoCustomersService struct {
 }
@@ -32,13 +36,13 @@ func (s *DemoCustomersService) Close() error {
 }
 
 // Add adds a single customer to psql database.
-func (s *DemoCustomersService) Add(customer Customer) (*Customer, error) {
-	return &Customer{}, nil
+func (s *DemoCustomersService) Add(customer api.Customer) (*api.Customer, error) {
+	return &api.Customer{}, nil
 }
 
 // Get retrieves a single customer from psql database.
-func (s *DemoCustomersService) Get(id string) (*Customer, error) {
-	return &Customer{
+func (s *DemoCustomersService) Get(id string) (*api.Customer, error) {
+	return &api.Customer{
 		ID:            "UNIQEID",
 		Name:          "Ari",
 		OwnedClusters: []string{"Eeast_cluster", "West_cluster"},
@@ -46,11 +50,11 @@ func (s *DemoCustomersService) Get(id string) (*Customer, error) {
 }
 
 // List retrieves a list of current customers stored in datastore.
-func (s *DemoCustomersService) List(args *ListArguments) (*CustomersList, error) {
-	var result *CustomersList
+func (s *DemoCustomersService) List(args *ListArguments) (*api.CustomerList, error) {
+	var result *api.CustomerList
 
-	result = &CustomersList{
-		Items: []*Customer{
+	result = &api.CustomerList{
+		Items: []*api.Customer{
 			{
 				ID:            "UNIQEID_1",
 				Name:          "Ari",

--- a/cmd/customers-service/service/sql_customers_service.go
+++ b/cmd/customers-service/service/sql_customers_service.go
@@ -24,6 +24,8 @@ import (
 	// Register the postgresql sql backend.
 	_ "github.com/lib/pq"
 	"github.com/segmentio/ksuid"
+
+	"github.com/container-mgmt/dedicated-portal/pkg/api"
 )
 
 // SQLCustomersService is a struct implementing the customer service interface,
@@ -51,13 +53,13 @@ func (s *SQLCustomersService) Close() error {
 }
 
 // Add adds a single customer to psql database.
-func (s *SQLCustomersService) Add(customer Customer) (*Customer, error) {
+func (s *SQLCustomersService) Add(customer api.Customer) (*api.Customer, error) {
 	id, err := ksuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}
 
-	result := Customer{
+	result := api.Customer{
 		ID:   id.String(),
 		Name: customer.Name,
 	}
@@ -101,8 +103,8 @@ func (s *SQLCustomersService) Add(customer Customer) (*Customer, error) {
 }
 
 // Get retrieves a single customer from psql database.
-func (s *SQLCustomersService) Get(id string) (*Customer, error) {
-	var result Customer
+func (s *SQLCustomersService) Get(id string) (*api.Customer, error) {
+	var result api.Customer
 
 	// Get the customer information
 	// If not customer found return nil pointer and nil error.
@@ -141,8 +143,8 @@ func (s *SQLCustomersService) Get(id string) (*Customer, error) {
 }
 
 // List retrieves a list of current customers stored in datastore.
-func (s *SQLCustomersService) List(args *ListArguments) (*CustomersList, error) {
-	var result *CustomersList
+func (s *SQLCustomersService) List(args *ListArguments) (*api.CustomerList, error) {
+	var result *api.CustomerList
 	var rows *sql.Rows
 	var err error
 	var page int64
@@ -165,10 +167,10 @@ func (s *SQLCustomersService) List(args *ListArguments) (*CustomersList, error) 
 	}
 
 	// Populate customers id's and names in their corresponding customers struct.
-	items := make([]*Customer, 0, numOfItems)
+	items := make([]*api.Customer, 0, numOfItems)
 	ids := make([]string, 0, numOfItems)
 	for rows.Next() {
-		var customer Customer
+		var customer api.Customer
 		if err = rows.Scan(&customer.ID, &customer.Name); err != nil {
 			return nil, err
 		}
@@ -220,7 +222,7 @@ func (s *SQLCustomersService) List(args *ListArguments) (*CustomersList, error) 
 		return nil, err
 	}
 
-	result = &CustomersList{
+	result = &api.CustomerList{
 		Items: items,
 		Page:  page,
 		Size:  int64(len(items)),

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the API types used by the clusters service.
+
+package api
+
+// Cluster represents a cluster.
+type Cluster struct {
+	UUID    string          `json:"id,omitempty"`
+	Name    string          `json:"name,omitempty"`
+	Nodes   ClusterNodes    `json:"nodes,omitempty"`
+	Memory  ClusterResource `json:"memory,omitempty"`
+	CPU     ClusterResource `json:"cpu,omitempty"`
+	Storage ClusterResource `json:"storage,omitempty"`
+}
+
+// ClusterNodes represents the node count inside a cluster.
+type ClusterNodes struct {
+	Total   int `json:"total,omitempty"`
+	Master  int `json:"master,omitempty"`
+	Infra   int `json:"infra,omitempty"`
+	Compute int `json:"compute,omitempty"`
+}
+
+// ClusterList is a list of clusters.
+type ClusterList struct {
+	Page  int        `json:"page"`
+	Size  int        `json:"size"`
+	Total int        `json:"total"`
+	Items []*Cluster `json:"items"`
+}
+
+// ClusterResource represents a resource availability in the cluster.
+type ClusterResource struct {
+	Used  int `json:"used,omitempty"`
+	Total int `json:"total,omitempty"`
+}

--- a/pkg/api/customer_types.go
+++ b/pkg/api/customer_types.go
@@ -14,12 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
+// This file contains the API types used by the customers service.
 
-// Customer struct is the internatl object representing information on
-// a single Customer.
+package api
+
+// Customer represents a customer.
 type Customer struct {
 	ID            string   `json:"id"`
 	Name          string   `json:"name"`
 	OwnedClusters []string `json:"owned_clusters"`
+}
+
+// CustomerList struct represents a list of customers.
+type CustomerList struct {
+	Page  int64       `json:"page,omitempty"`
+	Size  int64       `json:"size"`
+	Total int64       `json:"total"`
+	Items []*Customer `json:"items"`
 }

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -14,12 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
-
-// CustomersList struct is the internal object representing a list of Customers.
-type CustomersList struct {
-	Page  int64       `json:"page, omitempty"`
-	Size  int64       `json:"size"`
-	Total int64       `json:"total"`
-	Items []*Customer `json:"items"`
-}
+// Package api contains the definitions of the types that are used in the APIs of the services.
+// These types will be kept stable, backwards compatible and in sync with the OpenAPI specifications
+// of the services.
+package api


### PR DESCRIPTION
Currently the types used in the API are defined in the same packages where the servers are implemented. This makes it easy to hink that those types can be tweaked to make life simpler for the implementations of the servers. To avoid that this patch moves them to a new `api` package, so it is clearer that these types are part of the contract of the services, and that they need to be kept stable and backwards compatible.
