### PR TITLE
Rename cluster `UUID` to `ID`

### DIFF
--- a/cmd/clusters-service/clusters_service.go
+++ b/cmd/clusters-service/clusters_service.go
@@ -14,7 +14,7 @@ import (
 type ClustersService interface {
 	List(args ListArguments) (clusters api.ClusterList, err error)
 	Create(spec api.Cluster) (result api.Cluster, err error)
-	Get(uuid string) (result api.Cluster, err error)
+	Get(id string) (result api.Cluster, err error)
 }
 
 // GenericClustersService is a ClusterService placeholder implementation.
@@ -43,9 +43,9 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 		return api.ClusterList{}, fmt.Errorf("Error openning connection: %v", err)
 	}
 	defer db.Close()
-	rows, err := db.Query(`SELECT uuid, name
+	rows, err := db.Query(`SELECT id, name
 		FROM clusters
-		ORDER BY uuid
+		ORDER BY id
 		LIMIT $1
 		OFFSET $2`,
 		args.Size,
@@ -56,14 +56,14 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var uuid, name string
-		err = rows.Scan(&uuid, &name)
+		var id, name string
+		err = rows.Scan(&id, &name)
 		if err != nil {
 			return api.ClusterList{}, err
 		}
 		result.Items = append(result.Items, &api.Cluster{
 			Name: name,
-			UUID: uuid,
+			ID:   id,
 		})
 	}
 	err = rows.Err() // get any error encountered during iteration
@@ -77,7 +77,7 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 
 // Create saves a new cluster definition in the Database
 func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, err error) {
-	uuid, err := ksuid.NewRandom()
+	id, err := ksuid.NewRandom()
 	if err != nil {
 		return api.Cluster{}, err
 	}
@@ -88,7 +88,7 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 	defer db.Close()
 	stmt, err := db.Prepare(`
 		INSERT INTO clusters (
-			uuid, 
+			id,
 			name, 
 			master_nodes, 
 			infra_nodes, 
@@ -111,7 +111,7 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 	}
 	defer stmt.Close()
 	queryResult, err := stmt.Exec(
-		uuid,
+		id,
 		spec.Name,
 		spec.Nodes.Master,
 		spec.Nodes.Infra,
@@ -135,7 +135,7 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 	totalNodes := spec.Nodes.Master + spec.Nodes.Infra + spec.Nodes.Compute
 	return api.Cluster{
 		Name: spec.Name,
-		UUID: fmt.Sprintf("%s", uuid),
+		ID:   fmt.Sprintf("%s", id),
 		Nodes: api.ClusterNodes{
 			Total:   totalNodes,
 			Master:  spec.Nodes.Master,
@@ -156,7 +156,7 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 }
 
 // Get returns a single cluster by id
-func (cs GenericClustersService) Get(uuid string) (result api.Cluster, err error) {
+func (cs GenericClustersService) Get(id string) (result api.Cluster, err error) {
 	db, err := sql.Open("postgres", cs.connectionUrl)
 	if err != nil {
 		return api.Cluster{}, err
@@ -172,15 +172,15 @@ func (cs GenericClustersService) Get(uuid string) (result api.Cluster, err error
 		storage      int
 	)
 
-	err = db.QueryRow("SELECT uuid, name, master_nodes, infra_nodes, compute_nodes, memory, cpu_cores, storage FROM clusters	WHERE uuid = $1", uuid).Scan(
-		&uuid, &name, &masterNodes, &infraNodes, &computeNodes, &memory, &cpuCores, &storage)
+	err = db.QueryRow("SELECT id, name, master_nodes, infra_nodes, compute_nodes, memory, cpu_cores, storage FROM clusters	WHERE id = $1", id).Scan(
+		&id, &name, &masterNodes, &infraNodes, &computeNodes, &memory, &cpuCores, &storage)
 	if err != nil {
 		return api.Cluster{}, err
 	}
 	totalNodes := masterNodes + infraNodes + computeNodes
 	return api.Cluster{
 			Name: name,
-			UUID: uuid,
+			ID:   id,
 			Nodes: api.ClusterNodes{
 				Total:   totalNodes,
 				Master:  masterNodes,

--- a/cmd/clusters-service/handlers.go
+++ b/cmd/clusters-service/handlers.go
@@ -59,7 +59,7 @@ func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return
 	}
-	if spec.UUID != "" {
+	if spec.ID != "" {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "id must be empty"})
 		return
 	}
@@ -72,12 +72,12 @@ func (s Server) createCluster(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s Server) getCluster(w http.ResponseWriter, r *http.Request) {
-	uuid := mux.Vars(r)["uuid"]
-	if uuid == "" {
-		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "no uuid provided"})
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": "no id provided"})
 		return
 	}
-	cluster, err := s.clusterService.Get(uuid)
+	cluster, err := s.clusterService.Get(id)
 	if err != nil {
 		writeJSONResponse(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("%v", err)})
 		return

--- a/cmd/clusters-service/openapi.yaml
+++ b/cmd/clusters-service/openapi.yaml
@@ -89,11 +89,11 @@ components:
     Cluster:
       required:
         - name
-        - uuid
+        - id
       properties:
         name:
           type: string
-        uuid:
+        id:
           type: string
     ClustersList:
       type: array

--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -56,7 +56,7 @@ func (s Server) start() error {
 	apiRouter := mainRouter.PathPrefix("/api/clusters_mgmt/v1").Subrouter()
 	apiRouter.HandleFunc("/clusters", s.listClusters).Methods("GET")
 	apiRouter.HandleFunc("/clusters", s.createCluster).Methods("POST")
-	apiRouter.HandleFunc("/clusters/{uuid}", s.getCluster).Methods("GET")
+	apiRouter.HandleFunc("/clusters/{id}", s.getCluster).Methods("GET")
 
 	// Enable the access log:
 	loggedRouter := handlers.LoggingHandler(os.Stdout, mainRouter)

--- a/images/clusters-service/migrations/1530102671_create_schema.up.sql
+++ b/images/clusters-service/migrations/1530102671_create_schema.up.sql
@@ -1,3 +1,3 @@
 CREATE TABLE clusters (
-  uuid varchar(37) NOT NULL UNIQUE
+  id varchar(37) NOT NULL UNIQUE
 );

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -20,7 +20,7 @@ package api
 
 // Cluster represents a cluster.
 type Cluster struct {
-	UUID    string          `json:"id,omitempty"`
+	ID      string          `json:"id,omitempty"`
 	Name    string          `json:"name,omitempty"`
 	Nodes   ClusterNodes    `json:"nodes,omitempty"`
 	Memory  ClusterResource `json:"memory,omitempty"`


### PR DESCRIPTION
In general the name of the field/columns for primary keys should be `id`, regardless of what is the mechanism that is used to generate it.