### PR TITLE
Use `http.MethodGet` instead of `GET` string

### DIFF
--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -54,9 +54,9 @@ func (s Server) start() error {
 
 	// Create the API router:
 	apiRouter := mainRouter.PathPrefix("/api/clusters_mgmt/v1").Subrouter()
-	apiRouter.HandleFunc("/clusters", s.listClusters).Methods("GET")
-	apiRouter.HandleFunc("/clusters", s.createCluster).Methods("POST")
-	apiRouter.HandleFunc("/clusters/{uuid}", s.getCluster).Methods("GET")
+	apiRouter.HandleFunc("/clusters", s.listClusters).Methods(http.MethodGet)
+	apiRouter.HandleFunc("/clusters", s.createCluster).Methods(http.MethodPost)
+	apiRouter.HandleFunc("/clusters/{uuid}", s.getCluster).Methods(http.MethodGet)
 
 	// Enable the access log:
 	loggedRouter := handlers.LoggingHandler(os.Stdout, mainRouter)

--- a/cmd/customers-service/server.go
+++ b/cmd/customers-service/server.go
@@ -133,12 +133,12 @@ func runServe(cmd *cobra.Command, args []string) {
 
 	// Create the API router:
 	apiRouter := mainRouter.PathPrefix("/api/customers_mgmt/v1").Subrouter()
-	apiRouter.HandleFunc("/customers", server.getCustomersList).Methods("GET")
-	apiRouter.HandleFunc("/customers", server.addCustomer).Methods("POST")
-	apiRouter.HandleFunc("/customers/{id}", server.getCustomerByID).Methods("GET")
+	apiRouter.HandleFunc("/customers", server.getCustomersList).Methods(http.MethodGet)
+	apiRouter.HandleFunc("/customers", server.addCustomer).Methods(http.MethodPost)
+	apiRouter.HandleFunc("/customers/{id}", server.getCustomerByID).Methods(http.MethodGet)
 	apiRouter.Path("/customers").
 		Queries("page", "{[0-9]+}", "size", "{[0-9]+}").
-		Methods("GET").
+		Methods(http.MethodGet).
 		HandlerFunc(server.getCustomersList)
 
 	// If not in demo mode, check JWK and add a JWT middleware:


### PR DESCRIPTION
Currently all the places where we need to specify the name of an HTTP method repeat the corresponding `GET` or `POST` string. This patch changes all those places to use the `MethodGet` and `MethodPost` constants defined in the `http` package.