### PR TITLE
Create namespace per cluster

### DIFF
--- a/cmd/clusters-service/clusters_service.go
+++ b/cmd/clusters-service/clusters_service.go
@@ -100,6 +100,8 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 		return api.Cluster{}, err
 	}
 
+	spec.UUID = uuid
+
 	// Use cluster provisioner to Provision a cluster.
 	err = cs.provisioner.Provision(spec)
 	if err != nil {


### PR DESCRIPTION
## What this does?
Create a namespace per cluster deployment: thus, all of the custom resources required to provision each cluster are in their own respective namspaces.

cc: @cben @jhernand @zgalor  