### PR TITLE
Add State field to Cluster API type

### DIFF
--- a/cmd/clusters-service/README.adoc
+++ b/cmd/clusters-service/README.adoc
@@ -56,7 +56,8 @@ $ curl -X POST -H "Content-Type: application/json" \
   },
   "storage": {
     "total": 72
-  }
+  },
+  "state": "Installing"
 }
 ----
 
@@ -83,6 +84,7 @@ curl  http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters/17Y
   "storage": {
     "total": 72
   }
+  "state": "Ready"
 }
 ----
 

--- a/cmd/clusters-service/clusters_service.go
+++ b/cmd/clusters-service/clusters_service.go
@@ -70,7 +70,8 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 		compute_nodes,
 		memory,
 		cpu_cores,
-		storage
+		storage,
+		state
 		FROM clusters
 		ORDER BY id
 		LIMIT $1
@@ -93,6 +94,7 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 			memory       int
 			cpuCores     int
 			storage      int
+			state        api.ClusterState
 		)
 
 		err = rows.Scan(
@@ -104,7 +106,8 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 			&computeNodes,
 			&memory,
 			&cpuCores,
-			&storage)
+			&storage,
+			&state)
 		if err != nil {
 			return api.ClusterList{}, err
 		}
@@ -132,6 +135,7 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 				Total: storage,
 				Used:  0,
 			},
+			State: state,
 		})
 	}
 	err = rows.Err() // get any error encountered during iteration
@@ -172,7 +176,8 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 			compute_nodes,
 			memory,
 			cpu_cores,
-			storage
+			storage,
+			state
 		) VALUES (
 			$1,
 			$2,
@@ -182,7 +187,8 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 			$6,
 			$7,
 			$8,
-			$9)
+			$9,
+			$10)
 	`)
 	if err != nil {
 		return api.Cluster{}, err
@@ -197,7 +203,8 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 		spec.Nodes.Compute,
 		spec.Memory.Total,
 		spec.CPU.Total,
-		spec.Storage.Total)
+		spec.Storage.Total,
+		api.ClusterStateInstalling)
 	if err != nil {
 		return api.Cluster{}, err
 	}
@@ -234,6 +241,7 @@ func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, e
 			Total: spec.Storage.Total,
 			Used:  0,
 		},
+		State: api.ClusterStateInstalling,
 	}, nil
 
 }
@@ -254,6 +262,7 @@ func (cs GenericClustersService) Get(id string) (result api.Cluster, err error) 
 		memory       int
 		cpuCores     int
 		storage      int
+		state        api.ClusterState
 	)
 
 	err = db.QueryRow(`
@@ -266,7 +275,8 @@ func (cs GenericClustersService) Get(id string) (result api.Cluster, err error) 
 		compute_nodes,
 		memory,
 		cpu_cores,
-		storage
+		storage,
+		state
 	FROM clusters
 	WHERE id = $1`, id).Scan(
 		&id,
@@ -277,7 +287,8 @@ func (cs GenericClustersService) Get(id string) (result api.Cluster, err error) 
 		&computeNodes,
 		&memory,
 		&cpuCores,
-		&storage)
+		&storage,
+		&state)
 
 	if err != nil {
 		return api.Cluster{}, err
@@ -305,6 +316,7 @@ func (cs GenericClustersService) Get(id string) (result api.Cluster, err error) 
 				Total: storage,
 				Used:  0,
 			},
+			State: state,
 		},
 		nil
 }

--- a/cmd/clusters-service/data/migrations/1530102892_add_cluster_details.down.sql
+++ b/cmd/clusters-service/data/migrations/1530102892_add_cluster_details.down.sql
@@ -6,5 +6,7 @@ DROP COLUMN infra_nodes,
 DROP COLUMN compute_nodes, 
 DROP COLUMN memory, 
 DROP COLUMN cpu_cores,
-DROP COLUMN storage; 
+DROP COLUMN storage, 
+DROP COLUMN state;
+
 

--- a/cmd/clusters-service/data/migrations/1530102892_add_cluster_details.up.sql
+++ b/cmd/clusters-service/data/migrations/1530102892_add_cluster_details.up.sql
@@ -6,5 +6,6 @@ ADD COLUMN infra_nodes int,
 ADD COLUMN compute_nodes int, 
 ADD COLUMN memory int, 
 ADD COLUMN cpu_cores int,
-ADD COLUMN storage int; 
+ADD COLUMN storage int, 
+ADD COLUMN state text;
 

--- a/pkg/api/cluster_types.go
+++ b/pkg/api/cluster_types.go
@@ -18,6 +18,18 @@ limitations under the License.
 
 package api
 
+// ClusterState represents the state of a cluster
+type ClusterState string
+
+const (
+	// ClusterStateInstalling - the cluster is still installing
+	ClusterStateInstalling ClusterState = "Installing"
+	// ClusterStateReady - cluster is ready for use
+	ClusterStateReady ClusterState = "Ready"
+	// ClusterStateError - error during installation
+	ClusterStateError ClusterState = "Error"
+)
+
 // Cluster represents a cluster.
 type Cluster struct {
 	ID      string          `json:"id"`
@@ -27,6 +39,7 @@ type Cluster struct {
 	Memory  ClusterResource `json:"memory"`
 	CPU     ClusterResource `json:"cpu"`
 	Storage ClusterResource `json:"storage"`
+	State   ClusterState    `json:"state"`
 }
 
 // ClusterNodes represents the node count inside a cluster.


### PR DESCRIPTION
Add the field to the DB, and the API.
When a cluster is created the state is set to "Installing".
Currently this is not changed.
Status should be dynamically updated in the future.