### PR TITLE
Add `provision` parameter to cluster creation API

### DIFF
--- a/cmd/clusters-service/README.adoc
+++ b/cmd/clusters-service/README.adoc
@@ -60,6 +60,18 @@ $ curl -X POST -H "Content-Type: application/json" \
 }
 ----
 
+=== Create a cluster in the DB only
+When creating a new cluster the `provision` parameter can be provided (default=`true`).
+[source]
+----
+$ curl -X POST -H "Content-Type: application/json" \
+  --data @my_new_cluster.json \ http://clusters-service.127.0.0.1.nip.io/api/clusters_mgmt/v1/clusters?provision=false
+----
+
+
+This will not actually provision the cluster.
+This API can be used to sync with clusters provisioned by other services.
+
 == Get Cluster Details
 [source]
 ----

--- a/cmd/clusters-service/clusters_service.go
+++ b/cmd/clusters-service/clusters_service.go
@@ -29,7 +29,7 @@ import (
 // ClustersService performs operations on clusters.
 type ClustersService interface {
 	List(args ListArguments) (clusters api.ClusterList, err error)
-	Create(spec api.Cluster) (result api.Cluster, err error)
+	Create(spec api.Cluster, provision bool) (result api.Cluster, err error)
 	Get(id string) (result api.Cluster, err error)
 }
 
@@ -144,17 +144,19 @@ func (cs GenericClustersService) List(args ListArguments) (result api.ClusterLis
 }
 
 // Create saves a new cluster definition in the Database
-func (cs GenericClustersService) Create(spec api.Cluster) (result api.Cluster, err error) {
+func (cs GenericClustersService) Create(spec api.Cluster, provision bool) (result api.Cluster, err error) {
 	id, err := ksuid.NewRandom()
 	if err != nil {
 		return api.Cluster{}, err
 	}
 
-	// Use cluster provisioner to Provision a cluster.
-	err = cs.provisioner.Provision(spec)
-	if err != nil {
-		return api.Cluster{}, fmt.Errorf("An error occurred while trying	to provision cluster %s: %s",
-			spec.Name, err)
+	if provision {
+		// Use cluster provisioner to Provision a cluster.
+		err = cs.provisioner.Provision(spec)
+		if err != nil {
+			return api.Cluster{}, fmt.Errorf("An error occurred while trying to provision cluster %s: %s",
+				spec.Name, err)
+		}
 	}
 
 	db, err := sql.Open("postgres", cs.connectionURL)


### PR DESCRIPTION
This parameter is true by default.
If false the cluster will be created in the DB but not provisioned.
This can be used to sync with externally provisioned clusters.