### PR TITLE
change the name of the namespace

### DIFF
--- a/cmd/clusters-service/cluster_provisioner.go
+++ b/cmd/clusters-service/cluster_provisioner.go
@@ -47,7 +47,7 @@ type ClusterOperatorProvisioner struct {
 	k8sClient             *k8s.Clientset
 }
 
-const clusterNameSpace = "dedicated-portal"
+const clusterNameSpace = "unified-hybrid-cloud"
 
 // NewClusterOperatorProvisioner A constructor for ClusterOperatorProvisioner struct.
 func NewClusterOperatorProvisioner(k8sConfig *rest.Config) (*ClusterOperatorProvisioner, error) {

--- a/template.yml
+++ b/template.yml
@@ -31,7 +31,7 @@ parameters:
 
 - name: NAMESPACE
   description: The namespace where the objects will be created.
-  value: dedicated-portal
+  value: unified-hybrid-cloud
 
 - name: VERSION
   description: The version number of the project.


### PR DESCRIPTION
## What this does?

Changes our deployment namespace from `dedicated-portal` to `unified-hybrid-cloud`.

cc: @jhernand @cben @yaacov @zgalor 