### PR TITLE
All services use same convention

### DIFF
--- a/cmd/clusters-service/server.go
+++ b/cmd/clusters-service/server.go
@@ -49,7 +49,7 @@ import (
 var serveArgs struct {
 	jwkCertURL string
 	dbURL      string
-	demoMode   bool
+	demoMode   string
 }
 
 var serveCmd = &cobra.Command{
@@ -85,11 +85,11 @@ func init() {
 		"",
 		"The url endpoint for the JWK certs.",
 	)
-	flags.BoolVar(
+	flags.StringVar(
 		&serveArgs.demoMode,
 		"demo-mode",
-		false,
-		"Run in demo mode (no token needed).",
+		"false",
+		"If set to \"true\" run in demo mode (no token needed, return demo data).",
 	)
 	flags.StringVar(
 		&clusterOperatorKubeConfig,
@@ -136,7 +136,7 @@ func (s Server) start() error {
 	//
 	// When running on demo mode we want to bypass the JWT check
 	// and serve mock data.
-	if !serveArgs.demoMode {
+	if serveArgs.demoMode != "true" {
 		// Check for JWK cert cli arg:
 		if serveArgs.jwkCertURL == "" {
 			check(fmt.Errorf("flag missing: --jwk-certs-url"), "No cert URL defined")

--- a/cmd/customers-service/server.go
+++ b/cmd/customers-service/server.go
@@ -48,7 +48,7 @@ var serveArgs struct {
 	port       int
 	jwkCertURL string
 	dbURL      string
-	demoMode   bool
+	demoMode   string
 }
 
 // A static json file containing the openAPI json definitions
@@ -87,11 +87,11 @@ func init() {
 		"",
 		"The url endpoint for the JWK certs.",
 	)
-	flags.BoolVar(
+	flags.StringVar(
 		&serveArgs.demoMode,
 		"demo-mode",
-		false,
-		"Run in demo mode (no token needed, return demo data).",
+		"false",
+		"If set to \"true\" run in demo mode (no token needed, return demo data).",
 	)
 }
 
@@ -104,7 +104,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	//
 	// If not in demo mode, try to connect to the sql server.
 	// If we are in demo mode, connect to a demo data source.
-	if !serveArgs.demoMode {
+	if serveArgs.demoMode != "true" {
 		// Check for db url cli arg:
 		if serveArgs.dbURL == "" {
 			check(fmt.Errorf("flag missing: --db-url"), "No db URL defined")
@@ -150,7 +150,7 @@ func runServe(cmd *cobra.Command, args []string) {
 	//
 	// When running on demo mode we want to bypass the JWT check
 	// and serve mock data.
-	if !serveArgs.demoMode {
+	if serveArgs.demoMode != "true" {
 		// Check for JWK cert cli arg:
 		if serveArgs.jwkCertURL == "" {
 			check(fmt.Errorf("flag missing: --jwk-certs-url"), "No cert URL defined")

--- a/template.sh
+++ b/template.sh
@@ -29,6 +29,7 @@ oc process \
   --param=VERSION="${TEMPLATE_VERSION:-latest}" \
   --param=DOMAIN="${TEMPLATE_DOMAIN:-example.com}" \
   --param=PASSWORD="${TEMPLATE_PASSWORD:-redhat123}" \
+  --param=DEMO_MODE="${TEMPLATE_DEMO_MODE: }" \
 | \
 oc apply \
   --filename=-

--- a/template.sh
+++ b/template.sh
@@ -29,7 +29,7 @@ oc process \
   --param=VERSION="${TEMPLATE_VERSION:-latest}" \
   --param=DOMAIN="${TEMPLATE_DOMAIN:-example.com}" \
   --param=PASSWORD="${TEMPLATE_PASSWORD:-redhat123}" \
-  --param=DEMO_MODE="${TEMPLATE_DEMO_MODE: }" \
+  --param=DEMO_MODE="${TEMPLATE_DEMO_MODE:false}" \
 | \
 oc apply \
   --filename=-

--- a/template.yml
+++ b/template.yml
@@ -44,6 +44,9 @@ parameters:
 - name: PASSWORD
   description: Password for the database user.
 
+- name: DEMO_MODE
+  description: If set to "--demo-mode", services will run without authentication.
+
 objects:
 
 - apiVersion: apps/v1beta1
@@ -68,6 +71,7 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
           - serve
+          - ${DEMO_MODE}
           - --db-url=postgres://service:${PASSWORD}@localhost:5432/clusters?sslmode=disable
           - --jwk-certs-url=https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/certs
           command:
@@ -116,6 +120,8 @@ objects:
     to:
       kind: Service
       name: clusters-service
+    tls:
+      termination: edge
 
 - apiVersion: apps/v1beta1
   kind: Deployment
@@ -139,6 +145,7 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
           - serve
+          - ${DEMO_MODE}
           - --db-url=postgres://service:${PASSWORD}@localhost:5432/customers?sslmode=disable
           - --jwk-certs-url=https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/certs
         - name: postgresql

--- a/template.yml
+++ b/template.yml
@@ -45,7 +45,8 @@ parameters:
   description: Password for the database user.
 
 - name: DEMO_MODE
-  description: If set to "--demo-mode", services will run without authentication.
+  description: If set to true, services will run without authentication.
+  value: "false"
 
 objects:
 
@@ -71,7 +72,7 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
           - serve
-          - ${DEMO_MODE}
+          - --demo-mode=${DEMO_MODE}
           - --db-url=postgres://service:${PASSWORD}@localhost:5432/clusters?sslmode=disable
           - --jwk-certs-url=https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/certs
           command:
@@ -145,7 +146,7 @@ objects:
           imagePullPolicy: IfNotPresent
           args:
           - serve
-          - ${DEMO_MODE}
+          - --demo-mode=${DEMO_MODE}
           - --db-url=postgres://service:${PASSWORD}@localhost:5432/customers?sslmode=disable
           - --jwk-certs-url=https://developers.redhat.com/auth/realms/rhd/protocol/openid-connect/certs
         - name: postgresql


### PR DESCRIPTION
**Description**

Currently each service use different routing scheme, thie PR makes both use `edge` routing.

**Example**

Running the services in demo mode on local machine:
```
TEMPLATE_DEMO_MODE=--demo-mode ./hack/cluster-restart.sh
```

Routing table:
```
$ oc get route
NAME                HOST/PORT                            PATH      SERVICES            PORT      TERMINATION   WILDCARD
clusters-service    clusters-service.127.0.0.1.nip.io              clusters-service    <all>     edge          None
customers-service   customers-service.127.0.0.1.nip.io             customers-service   <all>     edge          None
```

Testing response:
```
curl -k https://customers-service.127.0.0.1.nip.io
curl -k https://clusters-service.127.0.0.1.nip.io
```