### PR TITLE
Rename "dedicated-portal" to "uhc"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,10 +80,10 @@ pipeline {
             done
 
             # Deploy the application:
-            oc ${OC_ARGS} new-project dedicated-portal || oc ${OC_ARGS} project dedicated-portal || true
+            oc ${OC_ARGS} new-project unified-hybrid-cloud || oc ${OC_ARGS} project unified-hybrid-cloud || true
             oc ${OC_ARGS} process \
               --filename=template.yml \
-              --param=NAMESPACE=dedicated-portal \
+              --param=NAMESPACE=unified-hybrid-cloud \
               --param=VERSION=${GIT_COMMIT} \
               --param=DOMAIN=${SSH_HOST} \
               --param=PASSWORD=redhat123 \

--- a/README.adoc
+++ b/README.adoc
@@ -23,8 +23,8 @@ the `make tars` command:
 ----
 $ make tars
 $ ls *.tar | sort
-dedicated-portal_clusters-service_latest.tar
-dedicated-portal_customers-service_latest.tar
+unified-hybrid-cloud_clusters-service_latest.tar
+unified-hybrid-cloud_customers-service_latest.tar
 ----
 
 Those `.tar` files can then be copied to the _OpenShift_ cluster, and
@@ -34,17 +34,17 @@ uploaded to the image registry:
 ----
 $ scp *.tar template.* myhost:.
 $ ssh root@myhost
-# docker load -i dedicated-portal_clusters-service_latest.tar
-# docker load -i dedicated-portal_customers-service_latest.tar
+# docker load -i unified-hybrid-cloud_clusters-service_latest.tar
+# docker load -i unified-hybrid-cloud_customers-service_latest.tar
 ----
 
 Then the `template.sh` script can be used to create and populate the
-`dedicated-portal` namespace:
+`unified-hybrid-cloud` namespace:
 
 [source]
 ----
 $ ./template.sh
-$ oc get pods -n dedicated-portal
+$ oc get pods -n unified-hybrid-cloud
 NAME                                READY  STATUS   RESTARTS  AGE
 clusters-db-59dbb97d4f-qdmjw        1/1    Running  0         1m
 clusters-service-6b4877b885-k7zg2   1/1    Running  0         1m
@@ -52,11 +52,11 @@ customers-db-6cc7fc8c49-7mh7t       1/1    Running  0         1m
 customers-service-7dfdf5b6b5-hqznw  1/1    Running  0         1m
 ----
 
-To undeploy the application remove the `dedicated-portal` namespace:
+To undeploy the application remove the `unified-hybrid-cloud` namespace:
 
 [source]
 ----
-$ oc delete namespace dedicated-portal
+$ oc delete namespace unified-hybrid-cloud
 ----
 
 == Deploying using oc cluster up

--- a/template.sh
+++ b/template.sh
@@ -20,12 +20,12 @@
 # the application.
 
 # Create the namespace:
-oc new-project dedicated-portal || oc project dedicated-portal || true
+oc new-project unified-hybrid-cloud || oc project unified-hybrid-cloud || true
 
 # Use the template to create the objects:
 oc process \
   --filename="template.yml" \
-  --param=NAMESPACE="${TEMPLATE_NAMESPACE:-dedicated-portal}" \
+  --param=NAMESPACE="${TEMPLATE_NAMESPACE:-unified-hybrid-cloud}" \
   --param=VERSION="${TEMPLATE_VERSION:-latest}" \
   --param=DOMAIN="${TEMPLATE_DOMAIN:-example.com}" \
   --param=PASSWORD="${TEMPLATE_PASSWORD:-redhat123}" \

--- a/template.yml
+++ b/template.yml
@@ -23,9 +23,9 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: dedicated-portal
+  name: unified-hybrid-cloud
   annotations:
-    description: "Dedicated Portal"
+    description: "Unified Hybrid Cloud"
 
 parameters:
 


### PR DESCRIPTION
## What this does?
Rename "dedicated-portal" to "unified-hybrid-cloud" (our new project name) in the resources we create on our various deployments. (Jenkins, oc template etc.)

Building on top of work done in #131 

cc: @jhernand @zgalor @yaacov @cben 